### PR TITLE
Feat: universityInfo 대학정보 목록 조회

### DIFF
--- a/src/main/java/com/likelion/boomarble/domain/universityInfo/controller/UniversityInfoController.java
+++ b/src/main/java/com/likelion/boomarble/domain/universityInfo/controller/UniversityInfoController.java
@@ -1,0 +1,29 @@
+package com.likelion.boomarble.domain.universityInfo.controller;
+
+import com.likelion.boomarble.domain.universityInfo.dto.UniversityInfoListDTO;
+import com.likelion.boomarble.domain.universityInfo.service.UniversityInfoService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/info")
+public class UniversityInfoController {
+
+    private final UniversityInfoService universityInfoService;
+
+    @GetMapping("")
+    public ResponseEntity getMissionList(
+            Authentication authentication,
+            @RequestParam(value = "country", defaultValue = "all") String country,
+            @RequestParam(value = "university", required = false) String university,
+            @RequestParam(value = "type", required = false) String type){
+        UniversityInfoListDTO universityInfoListDTO = universityInfoService.getUniversityInfoList(country, university, type);
+        return ResponseEntity.ok(universityInfoListDTO);
+    }
+}

--- a/src/main/java/com/likelion/boomarble/domain/universityInfo/dto/UniversityInfoListDTO.java
+++ b/src/main/java/com/likelion/boomarble/domain/universityInfo/dto/UniversityInfoListDTO.java
@@ -1,0 +1,25 @@
+package com.likelion.boomarble.domain.universityInfo.dto;
+
+import com.likelion.boomarble.domain.universityInfo.domain.UniversityInfo;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UniversityInfoListDTO {
+    private List<UniversityInfoViewDTO> universityInfoLists;
+    public static UniversityInfoListDTO from(List<UniversityInfo> universityInfos) {
+        List<UniversityInfoViewDTO> viewDTOList = universityInfos.stream()
+                .map(UniversityInfoViewDTO::of)
+                .collect(Collectors.toList());
+
+        return new UniversityInfoListDTO(viewDTOList);
+    }
+}

--- a/src/main/java/com/likelion/boomarble/domain/universityInfo/dto/UniversityInfoViewDTO.java
+++ b/src/main/java/com/likelion/boomarble/domain/universityInfo/dto/UniversityInfoViewDTO.java
@@ -1,0 +1,22 @@
+package com.likelion.boomarble.domain.universityInfo.dto;
+
+import com.likelion.boomarble.domain.universityInfo.domain.UniversityInfo;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter @Builder
+@NoArgsConstructor @AllArgsConstructor
+public class UniversityInfoViewDTO {
+    private String universityName;
+    private String universityCountry;
+    private String universityType;
+
+    public static UniversityInfoViewDTO of(UniversityInfo universityInfo){
+        return UniversityInfoViewDTO.builder()
+                .universityName(universityInfo.getName())
+                .universityCountry(universityInfo.getCountry().getName())
+                .universityType(universityInfo.getExType().getName()).build();
+    }
+}

--- a/src/main/java/com/likelion/boomarble/domain/universityInfo/repository/UniversityInfoRepository.java
+++ b/src/main/java/com/likelion/boomarble/domain/universityInfo/repository/UniversityInfoRepository.java
@@ -1,0 +1,10 @@
+package com.likelion.boomarble.domain.universityInfo.repository;
+
+import com.likelion.boomarble.domain.universityInfo.domain.UniversityInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UniversityInfoRepository extends JpaRepository<UniversityInfo, Long>, JpaSpecificationExecutor<UniversityInfo> {
+}

--- a/src/main/java/com/likelion/boomarble/domain/universityInfo/service/UniversityInfoService.java
+++ b/src/main/java/com/likelion/boomarble/domain/universityInfo/service/UniversityInfoService.java
@@ -1,0 +1,8 @@
+package com.likelion.boomarble.domain.universityInfo.service;
+
+import com.likelion.boomarble.domain.universityInfo.dto.UniversityInfoListDTO;
+
+public interface UniversityInfoService {
+
+    UniversityInfoListDTO getUniversityInfoList(String country, String university, String type);
+}

--- a/src/main/java/com/likelion/boomarble/domain/universityInfo/service/UniversityInfoServiceImpl.java
+++ b/src/main/java/com/likelion/boomarble/domain/universityInfo/service/UniversityInfoServiceImpl.java
@@ -1,0 +1,36 @@
+package com.likelion.boomarble.domain.universityInfo.service;
+
+import com.likelion.boomarble.domain.model.Country;
+import com.likelion.boomarble.domain.model.ExType;
+import com.likelion.boomarble.domain.universityInfo.domain.UniversityInfo;
+import com.likelion.boomarble.domain.universityInfo.dto.UniversityInfoListDTO;
+import com.likelion.boomarble.domain.universityInfo.repository.UniversityInfoRepository;
+import com.likelion.boomarble.domain.universityInfo.specification.UniversityInfoSpecifications;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class UniversityInfoServiceImpl implements UniversityInfoService{
+
+    private final UniversityInfoRepository universityInfoRepository;
+    @Override
+    @Transactional
+    public UniversityInfoListDTO getUniversityInfoList(String countryStr, String university, String type) {
+        Country country = null;
+        if (countryStr != null && !countryStr.equals("all")) country = Country.valueOf(countryStr);
+        ExType exType = null;
+        if (type != null) exType = ExType.valueOf(type);
+
+        Specification<UniversityInfo> spec = Specification.where(UniversityInfoSpecifications.hasCountry(country))
+                .and(UniversityInfoSpecifications.hasUniversity(university))
+                .and(UniversityInfoSpecifications.hasType(exType));
+
+        List<UniversityInfo> results = universityInfoRepository.findAll(spec);
+        return UniversityInfoListDTO.from(results);
+    }
+}

--- a/src/main/java/com/likelion/boomarble/domain/universityInfo/specification/UniversityInfoSpecifications.java
+++ b/src/main/java/com/likelion/boomarble/domain/universityInfo/specification/UniversityInfoSpecifications.java
@@ -1,0 +1,36 @@
+package com.likelion.boomarble.domain.universityInfo.specification;
+
+import com.likelion.boomarble.domain.model.Country;
+import com.likelion.boomarble.domain.model.ExType;
+import org.springframework.data.jpa.domain.Specification;
+import com.likelion.boomarble.domain.universityInfo.domain.UniversityInfo;
+
+public class UniversityInfoSpecifications {
+
+    public static Specification<UniversityInfo> hasCountry(Country country) {
+        return (root, query, criteriaBuilder) -> {
+            if ("all".equals(country)) {
+                return criteriaBuilder.conjunction();
+            }
+            return criteriaBuilder.equal(root.get("country"), country);
+        };
+    }
+
+    public static Specification<UniversityInfo> hasUniversity(String university) {
+        return (root, query, criteriaBuilder) -> {
+            if (university == null) {
+                return criteriaBuilder.conjunction();
+            }
+            return criteriaBuilder.equal(root.get("name"), university);
+        };
+    }
+
+    public static Specification<UniversityInfo> hasType(ExType type) {
+        return (root, query, criteriaBuilder) -> {
+            if (type == null) {
+                return criteriaBuilder.conjunction();
+            }
+            return criteriaBuilder.equal(root.get("exType"), type);
+        };
+    }
+}


### PR DESCRIPTION
### 작업한 내용
- 대학 정보 목록 조회를 구현했습니다. (예외 처리는 아직 적용안했습니다.)
- country, university, type을 파라미터로 받게 됩니다.
- 다중 조건 검색 구현을 위해 JPA Specification을 추가했습니다.(이와 관련해서 노션에 정리해놨습니다.)

### 추후 작업할 내용
- 유저 인증 관련 오류 수정(현재 수정 완료. 추후 pr 올리겠습니다!!)
- 대학 정보 상세 조회 구현
- 대학 목록 검색
