### PR TITLE
Feat: 대학 정보 검색 및 상세 조회

### DIFF
--- a/src/main/java/com/likelion/boomarble/domain/universityInfo/controller/UniversityInfoController.java
+++ b/src/main/java/com/likelion/boomarble/domain/universityInfo/controller/UniversityInfoController.java
@@ -1,14 +1,12 @@
 package com.likelion.boomarble.domain.universityInfo.controller;
 
+import com.likelion.boomarble.domain.universityInfo.dto.UniversityInfoDetailDTO;
 import com.likelion.boomarble.domain.universityInfo.dto.UniversityInfoListDTO;
 import com.likelion.boomarble.domain.universityInfo.service.UniversityInfoService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,12 +16,26 @@ public class UniversityInfoController {
     private final UniversityInfoService universityInfoService;
 
     @GetMapping("")
-    public ResponseEntity getMissionList(
+    public ResponseEntity getUniversityInfoList(
             Authentication authentication,
             @RequestParam(value = "country", defaultValue = "all") String country,
             @RequestParam(value = "university", required = false) String university,
             @RequestParam(value = "type", required = false) String type){
         UniversityInfoListDTO universityInfoListDTO = universityInfoService.getUniversityInfoList(country, university, type);
+        return ResponseEntity.ok(universityInfoListDTO);
+    }
+
+    @GetMapping("/{universityId}")
+    public ResponseEntity getUniversityInfoDetail(Authentication authentication, @PathVariable long universityId){
+        UniversityInfoDetailDTO universityInfoDetailDTO = universityInfoService.getUniversityInfoDetail(universityId);
+        return ResponseEntity.ok(universityInfoDetailDTO);
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity searchUniversityInfoList(
+            Authentication authentication,
+            @RequestParam(value = "keyword", required = false) String keyword){
+        UniversityInfoListDTO universityInfoListDTO = universityInfoService.searchUniversityInfoList(keyword);
         return ResponseEntity.ok(universityInfoListDTO);
     }
 }

--- a/src/main/java/com/likelion/boomarble/domain/universityInfo/domain/UniversityInfo.java
+++ b/src/main/java/com/likelion/boomarble/domain/universityInfo/domain/UniversityInfo.java
@@ -28,6 +28,8 @@ public class UniversityInfo {
     private int ibtQ;
     private int toeflQ;
     private int ieltsQ;
+    private String japaneseQ;
+    private String chineseQ;
     private String qualificationEtc;
     private String expCost;
     private String expCostDesc;
@@ -35,7 +37,7 @@ public class UniversityInfo {
     private String etc;
 
     @Builder
-    public UniversityInfo(String name, ExType exType, Country country, String period, int recruitNum, int gradeQ, int ibtQ, int toeflQ, int ieltsQ, String qualificationEtc, String expCost, String expCostDesc, String benefit, String etc) {
+    public UniversityInfo(String name, ExType exType, Country country, String period, int recruitNum, int gradeQ, int ibtQ, int toeflQ, int ieltsQ, String japaneseQ, String chineseQ, String qualificationEtc, String expCost, String expCostDesc, String benefit, String etc) {
         this.name = name;
         this.exType = exType;
         this.country = country;
@@ -45,6 +47,8 @@ public class UniversityInfo {
         this.ibtQ = ibtQ;
         this.toeflQ = toeflQ;
         this.ieltsQ = ieltsQ;
+        this.japaneseQ = japaneseQ;
+        this.chineseQ = chineseQ;
         this.qualificationEtc = qualificationEtc;
         this.expCost = expCost;
         this.expCostDesc = expCostDesc;

--- a/src/main/java/com/likelion/boomarble/domain/universityInfo/dto/UniversityInfoDetailDTO.java
+++ b/src/main/java/com/likelion/boomarble/domain/universityInfo/dto/UniversityInfoDetailDTO.java
@@ -1,0 +1,50 @@
+package com.likelion.boomarble.domain.universityInfo.dto;
+
+import com.likelion.boomarble.domain.universityInfo.domain.UniversityInfo;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UniversityInfoDetailDTO {
+    private String universityName;
+    private String exType; // 교환유형(교환학생, 7+1)
+    private String country;
+    private String period; // 파견기간
+    private int recruitNum; // 선발인원
+    private int gradeQ; // 지원자격 학점
+    private int ibtQ; // 지원자격 ibt
+    private int toeflQ; // 지원자격 토플
+    private int ielts; // 지원자격 ielts
+    private String japaneseQ; // 지원자격 jlpt
+    private String chineseQ; // 지원자격 hsk
+    private String qualificationEtc; // 지원자격 기타
+    private String expCost; // 예상 비용
+    private String expCostDesc; // 예상 비용 설명
+    private String benefit; // 프로그램 혜택
+    private String etc; // 비고
+
+    public static UniversityInfoDetailDTO from(UniversityInfo universityInfo) {
+        return UniversityInfoDetailDTO.builder()
+                .universityName(universityInfo.getName())
+                .exType(universityInfo.getExType().getName())
+                .country(universityInfo.getCountry().getName())
+                .period(universityInfo.getPeriod())
+                .recruitNum(universityInfo.getRecruitNum())
+                .gradeQ(universityInfo.getGradeQ())
+                .ibtQ(universityInfo.getIbtQ())
+                .toeflQ(universityInfo.getToeflQ())
+                .ielts(universityInfo.getIeltsQ())
+                .japaneseQ(universityInfo.getJapaneseQ())
+                .chineseQ(universityInfo.getChineseQ())
+                .qualificationEtc(universityInfo.getQualificationEtc())
+                .expCost(universityInfo.getExpCost())
+                .expCostDesc(universityInfo.getExpCostDesc())
+                .benefit(universityInfo.getBenefit())
+                .etc(universityInfo.getEtc()).build();
+    }
+}

--- a/src/main/java/com/likelion/boomarble/domain/universityInfo/exception/UniversityInfoNotFoundException.java
+++ b/src/main/java/com/likelion/boomarble/domain/universityInfo/exception/UniversityInfoNotFoundException.java
@@ -1,0 +1,7 @@
+package com.likelion.boomarble.domain.universityInfo.exception;
+
+public class UniversityInfoNotFoundException extends RuntimeException{
+    public UniversityInfoNotFoundException(String message){
+        super(message);
+    }
+}

--- a/src/main/java/com/likelion/boomarble/domain/universityInfo/repository/UniversityInfoRepository.java
+++ b/src/main/java/com/likelion/boomarble/domain/universityInfo/repository/UniversityInfoRepository.java
@@ -5,6 +5,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface UniversityInfoRepository extends JpaRepository<UniversityInfo, Long>, JpaSpecificationExecutor<UniversityInfo> {
+    List<UniversityInfo> findAllByNameContaining(String keyword);
 }

--- a/src/main/java/com/likelion/boomarble/domain/universityInfo/service/UniversityInfoService.java
+++ b/src/main/java/com/likelion/boomarble/domain/universityInfo/service/UniversityInfoService.java
@@ -1,8 +1,13 @@
 package com.likelion.boomarble.domain.universityInfo.service;
 
+import com.likelion.boomarble.domain.universityInfo.dto.UniversityInfoDetailDTO;
 import com.likelion.boomarble.domain.universityInfo.dto.UniversityInfoListDTO;
 
 public interface UniversityInfoService {
 
     UniversityInfoListDTO getUniversityInfoList(String country, String university, String type);
+
+    UniversityInfoDetailDTO getUniversityInfoDetail(long universityId);
+
+    UniversityInfoListDTO searchUniversityInfoList(String keyword);
 }

--- a/src/main/java/com/likelion/boomarble/domain/universityInfo/service/UniversityInfoServiceImpl.java
+++ b/src/main/java/com/likelion/boomarble/domain/universityInfo/service/UniversityInfoServiceImpl.java
@@ -3,7 +3,9 @@ package com.likelion.boomarble.domain.universityInfo.service;
 import com.likelion.boomarble.domain.model.Country;
 import com.likelion.boomarble.domain.model.ExType;
 import com.likelion.boomarble.domain.universityInfo.domain.UniversityInfo;
+import com.likelion.boomarble.domain.universityInfo.dto.UniversityInfoDetailDTO;
 import com.likelion.boomarble.domain.universityInfo.dto.UniversityInfoListDTO;
+import com.likelion.boomarble.domain.universityInfo.exception.UniversityInfoNotFoundException;
 import com.likelion.boomarble.domain.universityInfo.repository.UniversityInfoRepository;
 import com.likelion.boomarble.domain.universityInfo.specification.UniversityInfoSpecifications;
 import lombok.RequiredArgsConstructor;
@@ -32,5 +34,19 @@ public class UniversityInfoServiceImpl implements UniversityInfoService{
 
         List<UniversityInfo> results = universityInfoRepository.findAll(spec);
         return UniversityInfoListDTO.from(results);
+    }
+    @Override
+    @Transactional
+    public UniversityInfoDetailDTO getUniversityInfoDetail(long universityId) {
+        UniversityInfo universityInfo = universityInfoRepository.findById(universityId)
+                .orElseThrow(() -> new UniversityInfoNotFoundException("해당 대학 정보가 없습니다."));
+        return UniversityInfoDetailDTO.from(universityInfo);
+    }
+
+    @Override
+    @Transactional
+    public UniversityInfoListDTO searchUniversityInfoList(String keyword) {
+        List<UniversityInfo> universityInfoList = universityInfoRepository.findAllByNameContaining(keyword);
+        return UniversityInfoListDTO.from(universityInfoList);
     }
 }


### PR DESCRIPTION
### 작업한 내용
- 대학 정보 검색을 구현했습니다. 
- 대학 정보 상세 조회를 구현했습니다.

### 논의할 내용
- 현재는 대학교 이름 검색만 가능한데, 교환 유형과 국가도 검색 가능하게 할까요..? 원래 검색 가능하게 바꾸려다가 필터링 기능이 있어서  굳이 필요할까 싶기도 하네욤,,,🤔 (-> 대학교 이름만 검색 가능한걸로~~)

### 추후 작업할 내용
- 모의 지원 구현
- 대학 정보 생성 구현 (이거는 테스트용 더미데이터 생성하기 위해서 만들려고 합니다!  DB에 직접 데이터 넣었다가 나중에 낭패를 본 적이 있어...포스트맨으로 직접 넣으려고 합니당)
