### PR TITLE
Feat: 대학 정보 상세페이지 좋아요 기능

### DIFF
--- a/src/main/java/com/likelion/boomarble/domain/model/Like.java
+++ b/src/main/java/com/likelion/boomarble/domain/model/Like.java
@@ -3,6 +3,7 @@ package com.likelion.boomarble.domain.model;
 import com.likelion.boomarble.domain.universityInfo.domain.UniversityInfo;
 import com.likelion.boomarble.domain.user.domain.User;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -22,5 +23,11 @@ public class Like {
     @ManyToOne
     @JoinColumn(name = "universityInfo")
     private UniversityInfo universityInfo;
+
+    @Builder
+    public Like(User user, UniversityInfo universityInfo){
+        this.user = user;
+        this.universityInfo = universityInfo;
+    }
 
 }

--- a/src/main/java/com/likelion/boomarble/domain/model/repository/LikeRepository.java
+++ b/src/main/java/com/likelion/boomarble/domain/model/repository/LikeRepository.java
@@ -1,0 +1,14 @@
+package com.likelion.boomarble.domain.model.repository;
+
+import com.likelion.boomarble.domain.model.Like;
+import com.likelion.boomarble.domain.universityInfo.domain.UniversityInfo;
+import com.likelion.boomarble.domain.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface LikeRepository extends JpaRepository<Like, Long> {
+    Optional<Like> findByUserAndUniversityInfo(User user, UniversityInfo universityInfo);
+}

--- a/src/main/java/com/likelion/boomarble/domain/universityInfo/controller/UniversityInfoController.java
+++ b/src/main/java/com/likelion/boomarble/domain/universityInfo/controller/UniversityInfoController.java
@@ -7,6 +7,7 @@ import com.likelion.boomarble.domain.universityInfo.dto.RegisterUniversityInfoDT
 import com.likelion.boomarble.domain.universityInfo.dto.UniversityInfoDetailDTO;
 import com.likelion.boomarble.domain.universityInfo.dto.UniversityInfoListDTO;
 import com.likelion.boomarble.domain.universityInfo.service.UniversityInfoService;
+import com.likelion.boomarble.domain.user.domain.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -43,10 +44,36 @@ public class UniversityInfoController {
         return ResponseEntity.ok(universityInfoListDTO);
     }
 
+    @PostMapping("/{universityId}/like")
+    public ResponseEntity likeUniversityInfo(
+            Authentication authentication,
+            @PathVariable long universityId){
+        long userId = getUserPk(authentication);
+        int result = universityInfoService.likeUniversityInfo(universityId, userId);
+        if(result == 400) return ResponseEntity.badRequest().body("잘못된 요청입니다.");
+        else if(result == 409) return ResponseEntity.badRequest().body("이미 좋아요를 눌렀습니다.");
+        return ResponseEntity.ok("좋아요가 정상적으로 반영이 되었습니다.");
+    }
+
+    @DeleteMapping("/{universityId}/like")
+    public ResponseEntity unlikeUniversityInfo(Authentication authentication, @PathVariable long universityId){
+        long userId = getUserPk(authentication);
+        int result = universityInfoService.unlikeUniversityInfo(universityId, userId);
+        if(result == 400) return ResponseEntity.badRequest().body("잘못된 요청입니다.");
+        else if(result == 404) return ResponseEntity.badRequest().body("좋아요를 누른 적이 없습니다.");
+        return ResponseEntity.ok("좋아요가 정상적으로 취소가 되었습니다.");
+    }
+
+
     // 이 부분은 대학 정보 테이블 수정 후 다시 구현할 예정
-//    @PostMapping("/register")
-//    public ResponseEntity registerUniversityInfo(Authentication authentication, @RequestBody RegisterUniversityInfoDTO registerUniversityInfoDTO){
-//        UniversityInfo universityInfo = universityInfoService.registerUniversityInfo(registerUniversityInfoDTO);
-//        return ResponseEntity.ok(universityInfo);
-//    }
+    @PostMapping("/register")
+    public ResponseEntity registerUniversityInfo(Authentication authentication, @RequestBody RegisterUniversityInfoDTO registerUniversityInfoDTO){
+        UniversityInfo universityInfo = universityInfoService.registerUniversityInfo(registerUniversityInfoDTO);
+        return ResponseEntity.ok(universityInfo);
+    }
+
+    public long getUserPk(Authentication authentication){
+        CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
+        return customUserDetails.getUserPk();
+    }
 }

--- a/src/main/java/com/likelion/boomarble/domain/universityInfo/service/UniversityInfoService.java
+++ b/src/main/java/com/likelion/boomarble/domain/universityInfo/service/UniversityInfoService.java
@@ -2,6 +2,7 @@ package com.likelion.boomarble.domain.universityInfo.service;
 
 import com.likelion.boomarble.domain.model.Country;
 import com.likelion.boomarble.domain.model.ExType;
+import com.likelion.boomarble.domain.model.Like;
 import com.likelion.boomarble.domain.universityInfo.domain.UniversityInfo;
 import com.likelion.boomarble.domain.universityInfo.dto.*;
 
@@ -18,4 +19,8 @@ public interface UniversityInfoService {
     UniversityInfo registerUniversityInfo(RegisterUniversityInfoDTO registerUniversityInfoDTO);
 
     UniversityNameListDTO getUniversitiedByCountry(Country country);
+
+    int likeUniversityInfo(long universityId, long userId);
+
+    int unlikeUniversityInfo(long universityId, long userId);
 }

--- a/src/main/java/com/likelion/boomarble/domain/universityInfo/service/UniversityInfoServiceImpl.java
+++ b/src/main/java/com/likelion/boomarble/domain/universityInfo/service/UniversityInfoServiceImpl.java
@@ -2,23 +2,32 @@ package com.likelion.boomarble.domain.universityInfo.service;
 
 import com.likelion.boomarble.domain.model.Country;
 import com.likelion.boomarble.domain.model.ExType;
+import com.likelion.boomarble.domain.model.Like;
+import com.likelion.boomarble.domain.model.repository.LikeRepository;
 import com.likelion.boomarble.domain.universityInfo.domain.UniversityInfo;
 import com.likelion.boomarble.domain.universityInfo.dto.*;
 import com.likelion.boomarble.domain.universityInfo.exception.UniversityInfoNotFoundException;
 import com.likelion.boomarble.domain.universityInfo.repository.UniversityInfoRepository;
 import com.likelion.boomarble.domain.universityInfo.specification.UniversityInfoSpecifications;
+import com.likelion.boomarble.domain.user.domain.User;
+import com.likelion.boomarble.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class UniversityInfoServiceImpl implements UniversityInfoService{
 
     private final UniversityInfoRepository universityInfoRepository;
+    private final UserRepository userRepository;
+    private final LikeRepository likeRepository;
+
     @Override
     @Transactional
     public UniversityInfoListDTO getUniversityInfoList(Country country, String university, ExType type) {
@@ -36,24 +45,47 @@ public class UniversityInfoServiceImpl implements UniversityInfoService{
                 .orElseThrow(() -> new UniversityInfoNotFoundException("해당 대학 정보가 없습니다."));
         return UniversityInfoDetailDTO.from(universityInfo);
     }
-
     @Override
     @Transactional
     public UniversityInfoListDTO searchUniversityInfoList(String keyword) {
         List<UniversityInfo> universityInfoList = universityInfoRepository.findAllByNameContaining(keyword);
         return UniversityInfoListDTO.from(universityInfoList);
     }
-
-    @Override
-    @Transactional
-    public UniversityInfo registerUniversityInfo(RegisterUniversityInfoDTO registerUniversityInfoDTO) {
-        return new UniversityInfo(registerUniversityInfoDTO);
-    }
-
     @Override
     @Transactional
     public UniversityNameListDTO getUniversitiedByCountry(Country country) {
         List<UniversityInfo> universities = universityInfoRepository.findAllByCountry(country);
         return UniversityNameListDTO.from(universities);
+    }
+    @Override
+    @Transactional
+    public int likeUniversityInfo(long universityId, long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UsernameNotFoundException("해당 유저가 존재하지 않습니다."));
+        UniversityInfo universityInfo = universityInfoRepository.findById(universityId)
+                .orElseThrow(() -> new UniversityInfoNotFoundException("해당 대학정보가 존재하지 않습니다."));
+        if (likeRepository.findByUserAndUniversityInfo(user, universityInfo).isPresent()) return 409;
+        if (likeRepository.save(new Like(user, universityInfo)) == null) return 400;
+        return 200;
+    }
+    @Override
+    @Transactional
+    public int unlikeUniversityInfo(long universityId, long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UsernameNotFoundException("해당 유저가 존재하지 않습니다."));
+        UniversityInfo universityInfo = universityInfoRepository.findById(universityId)
+                .orElseThrow(() -> new UniversityInfoNotFoundException("해당 대학정보가 존재하지 않습니다."));
+        Optional<Like> like = likeRepository.findByUserAndUniversityInfo(user, universityInfo);
+        if (like.isPresent()){
+            likeRepository.delete(like.get());
+            if (likeRepository.findByUserAndUniversityInfo(user, universityInfo).isEmpty()) return 200;
+            else return 400;
+        } else return 404;
+    }
+    @Override
+    @Transactional
+    public UniversityInfo registerUniversityInfo(RegisterUniversityInfoDTO registerUniversityInfoDTO) {
+        UniversityInfo universityInfo = new UniversityInfo(registerUniversityInfoDTO);
+        return universityInfoRepository.save(universityInfo);
     }
 }


### PR DESCRIPTION
### 작업한 내용
- 대학정보 상세페이지 좋아요 및 좋아요 취소 기능을 구현했습니다.
- "잘못된 요청 / 좋아요를 누른 적이 없을 때 or 이미 좋아요를 눌렀을 때 / 정상 요청"에 따라 상태 코드 분기 처리를 했습니다.

### 논의할 내용
- 지금 좋아요랑 스크랩에서 count에 대한 필드가 없는데 추가하는거에 대해서 어떻게 생각하시나요?? 현재 목록이나 상세 조회 페이지에서 몇 개의 좋아요를 받았는지, 몇 번 스크랩을 해 갔는지에 대한 정보가 없긴 해요!!

### 추후 작업할 내용
- 현재 dev에 있는 코드 먼저 배포 진행 후 테스트
- 모의 지원
