### PR TITLE
Feat: 상세, 목록 조회 시 해시태그 추가

### DIFF
--- a/src/main/java/com/likelion/boomarble/domain/community/controller/CommunityController.java
+++ b/src/main/java/com/likelion/boomarble/domain/community/controller/CommunityController.java
@@ -4,6 +4,7 @@ import com.likelion.boomarble.domain.community.domain.Community;
 import com.likelion.boomarble.domain.community.dto.CommunityCreateDTO;
 import com.likelion.boomarble.domain.community.dto.CommunityDetailDTO;
 import com.likelion.boomarble.domain.community.dto.CommunityListDTO;
+import com.likelion.boomarble.domain.community.dto.CommunityTagMap;
 import com.likelion.boomarble.domain.community.repository.CommunityRepository;
 import com.likelion.boomarble.domain.community.service.CommunityService;
 import com.likelion.boomarble.domain.model.Country;
@@ -13,6 +14,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/likelion/boomarble/domain/community/domain/Community.java
+++ b/src/main/java/com/likelion/boomarble/domain/community/domain/Community.java
@@ -1,17 +1,19 @@
 package com.likelion.boomarble.domain.community.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.likelion.boomarble.domain.community.dto.CommunityCreateDTO;
+import com.likelion.boomarble.domain.community.dto.CommunityTagMap;
 import com.likelion.boomarble.domain.model.Country;
 import com.likelion.boomarble.domain.model.ExType;
 import com.likelion.boomarble.domain.model.Tag;
 import com.likelion.boomarble.domain.universityInfo.domain.UniversityInfo;
 import com.likelion.boomarble.domain.user.domain.User;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.util.List;
 
 @Entity
 @Getter
@@ -31,17 +33,13 @@ public class Community {
     @ManyToOne
     @JoinColumn(name = "university")
     private UniversityInfo university;
+    @JsonIgnore
+    @OneToMany(mappedBy = "community")
+    private List<CommunityTagMap> communityTagList;
 
-//    @Builder
-//    public Community(User writer, String title, String content, String semester, ExType exType, Country country, UniversityInfo university) {
-//        this.writer = writer;
-//        this.title = title;
-//        this.content = content;
-//        this.semester = semester;
-//        this.exType = exType;
-//        this.country = country;
-//        this.university = university;
-//    }
+    public void addCommunityTagList(CommunityTagMap communityTagMap) {
+        this.communityTagList.add(communityTagMap);
+    }
 
     public Community(CommunityCreateDTO communityCreateDTO, User user){
         this.writer = user;

--- a/src/main/java/com/likelion/boomarble/domain/community/dto/CommunityCreateDTO.java
+++ b/src/main/java/com/likelion/boomarble/domain/community/dto/CommunityCreateDTO.java
@@ -3,12 +3,15 @@ package com.likelion.boomarble.domain.community.dto;
 import com.likelion.boomarble.domain.community.domain.Community;
 import com.likelion.boomarble.domain.model.Country;
 import com.likelion.boomarble.domain.model.ExType;
+import com.likelion.boomarble.domain.model.Tag;
 import com.likelion.boomarble.domain.universityInfo.domain.UniversityInfo;
 import com.likelion.boomarble.domain.user.domain.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Getter
 @Builder

--- a/src/main/java/com/likelion/boomarble/domain/community/dto/CommunityDetailDTO.java
+++ b/src/main/java/com/likelion/boomarble/domain/community/dto/CommunityDetailDTO.java
@@ -1,15 +1,14 @@
 package com.likelion.boomarble.domain.community.dto;
 
 import com.likelion.boomarble.domain.community.domain.Community;
-import com.likelion.boomarble.domain.model.Country;
-import com.likelion.boomarble.domain.model.ExType;
+import com.likelion.boomarble.domain.model.Tag;
 import com.likelion.boomarble.domain.user.domain.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.Optional;
+import java.util.List;
 
 @Getter
 @Builder
@@ -23,8 +22,10 @@ public class CommunityDetailDTO {
     private String university;
     private String exType;
     private String semester;
+    private List<CommunityTagMap> communityTagList;
 
     public static CommunityDetailDTO from(Community community) {
+
         return CommunityDetailDTO.builder()
                 .communityWriter(community.getWriter())
                 .title(community.getTitle())
@@ -32,6 +33,8 @@ public class CommunityDetailDTO {
                 .country(String.valueOf(community.getCountry()))
                 .university(String.valueOf(community.getUniversity()))
                 .exType(String.valueOf(community.getExType()))
-                .semester(String.valueOf(community.getSemester())).build();
+                .semester(String.valueOf(community.getSemester()))
+                .communityTagList(community.getCommunityTagList())
+                .build();
     }
 }

--- a/src/main/java/com/likelion/boomarble/domain/community/dto/CommunityTagMap.java
+++ b/src/main/java/com/likelion/boomarble/domain/community/dto/CommunityTagMap.java
@@ -1,5 +1,6 @@
 package com.likelion.boomarble.domain.community.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.likelion.boomarble.domain.community.domain.Community;
 import com.likelion.boomarble.domain.model.Tag;
 import lombok.AllArgsConstructor;
@@ -14,9 +15,11 @@ import javax.persistence.*;
 @AllArgsConstructor
 public class CommunityTagMap {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @JsonIgnore
     private long id;
 
     @ManyToOne
+    @JsonIgnore
     @JoinColumn(name = "community_id")
     private Community community;
 

--- a/src/main/java/com/likelion/boomarble/domain/community/dto/CommunityViewDTO.java
+++ b/src/main/java/com/likelion/boomarble/domain/community/dto/CommunityViewDTO.java
@@ -1,10 +1,13 @@
 package com.likelion.boomarble.domain.community.dto;
 
 import com.likelion.boomarble.domain.community.domain.Community;
+import com.likelion.boomarble.domain.model.Tag;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Getter @Builder
 @AllArgsConstructor @NoArgsConstructor
@@ -13,12 +16,14 @@ public class CommunityViewDTO {
     private String communityCountry;
     private String communityType;
     private String communitySemester;
+    private List<CommunityTagMap> communityTagList;
 
     public static CommunityViewDTO of (Community community) {
         return CommunityViewDTO.builder()
                 .communityTitle(community.getTitle())
                 .communityCountry(community.getCountry().getName())
                 .communityType(community.getExType().getName())
-                .communitySemester(community.getSemester()).build();
+                .communitySemester(community.getSemester())
+                .communityTagList(community.getCommunityTagList()).build();
     }
 }

--- a/src/main/java/com/likelion/boomarble/domain/community/repository/CommunityTagRepository.java
+++ b/src/main/java/com/likelion/boomarble/domain/community/repository/CommunityTagRepository.java
@@ -1,7 +1,13 @@
 package com.likelion.boomarble.domain.community.repository;
 
+import com.likelion.boomarble.domain.community.domain.Community;
 import com.likelion.boomarble.domain.community.dto.CommunityTagMap;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
+@Repository
 public interface CommunityTagRepository extends JpaRepository<CommunityTagMap, Long> {
+    List<CommunityTagMap> findAllByCommunity(Community community);
 }

--- a/src/main/java/com/likelion/boomarble/domain/community/service/CommunityService.java
+++ b/src/main/java/com/likelion/boomarble/domain/community/service/CommunityService.java
@@ -4,13 +4,15 @@ import com.likelion.boomarble.domain.community.domain.Community;
 import com.likelion.boomarble.domain.community.dto.CommunityCreateDTO;
 import com.likelion.boomarble.domain.community.dto.CommunityDetailDTO;
 import com.likelion.boomarble.domain.community.dto.CommunityListDTO;
+import com.likelion.boomarble.domain.community.dto.CommunityTagMap;
 import com.likelion.boomarble.domain.model.Country;
 import com.likelion.boomarble.domain.model.ExType;
+
+import java.util.List;
 
 public interface CommunityService {
     Community createCommunityPost(Long userId, CommunityCreateDTO communityCreateDTO);
     CommunityListDTO getCommunityList(Country country, String university, ExType type, String semester);
-
     CommunityDetailDTO getCommunityDetail(long postId);
-
+//    List<String> getTagList(long postId);
 }

--- a/src/main/java/com/likelion/boomarble/domain/community/service/CommunityServiceImpl.java
+++ b/src/main/java/com/likelion/boomarble/domain/community/service/CommunityServiceImpl.java
@@ -1,10 +1,7 @@
 package com.likelion.boomarble.domain.community.service;
 
 import com.likelion.boomarble.domain.community.domain.Community;
-import com.likelion.boomarble.domain.community.dto.CommunityCreateDTO;
-import com.likelion.boomarble.domain.community.dto.CommunityDetailDTO;
-import com.likelion.boomarble.domain.community.dto.CommunityListDTO;
-import com.likelion.boomarble.domain.community.dto.CommunityTagMap;
+import com.likelion.boomarble.domain.community.dto.*;
 import com.likelion.boomarble.domain.community.exception.CommunityNotFoundException;
 import com.likelion.boomarble.domain.community.repository.CommunityRepository;
 import com.likelion.boomarble.domain.community.repository.CommunityTagRepository;
@@ -20,6 +17,7 @@ import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -60,7 +58,9 @@ public class CommunityServiceImpl implements CommunityService {
                 checkTag = new Tag(tag, 1);
                 tagRepository.save(checkTag);
             }
-            communityTagRepository.save(new CommunityTagMap(community, checkTag));
+            CommunityTagMap communityTagMap = new CommunityTagMap(community, checkTag);
+            communityTagRepository.save(communityTagMap);
+            community.addCommunityTagList(communityTagMap);
         }
         return result;
     }
@@ -72,4 +72,18 @@ public class CommunityServiceImpl implements CommunityService {
                 .orElseThrow(() -> new CommunityNotFoundException("해당 커뮤니티 글이 없습니다."));
         return CommunityDetailDTO.from(community);
     }
+
+//    @Override
+//    @Transactional
+//    public List<String> getTagList(long postId) {
+//        Community community = communityRepository.findById(postId)
+//                .orElseThrow(() -> new CommunityNotFoundException("해당 커뮤니티 글이 없습니다."));
+//        List<CommunityTagMap> communityTagMapList = communityTagRepository.findAllByCommunity(community);
+//        List<String> tagList = new ArrayList<>();
+//        for(CommunityTagMap communityTagMap: communityTagMapList){
+//            String tag = communityTagMap.getTag().getName();
+//            tagList.add(tag);
+//        }
+//        return tagList;
+//    }
 }

--- a/src/main/java/com/likelion/boomarble/domain/model/Tag.java
+++ b/src/main/java/com/likelion/boomarble/domain/model/Tag.java
@@ -1,5 +1,6 @@
 package com.likelion.boomarble.domain.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,8 +16,10 @@ import javax.persistence.Id;
 public class Tag {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @JsonIgnore
     private long id;
     private String name;
+    @JsonIgnore
     private int cnt;
 
     @Builder


### PR DESCRIPTION
### 작업한 내용
- 상세조회, 목록조회 시 해시태그를 조회할 수 있도록 바꾸었습니다.

### 논의할 내용
- 해시태그 리스트를 어떻게 구성해야 할지 모르겠습니다.

### 추후 작업할 내용
- 대학, 국가 등 선택 요소를 추가해서 해시태그와 함께 태그리스트로 프론트에 전달하도록 작업할 예정입니다.
