### PR TITLE
fix: DB 필드 길이 확장

### DIFF
--- a/src/main/java/com/likelion/boomarble/domain/community/domain/Community.java
+++ b/src/main/java/com/likelion/boomarble/domain/community/domain/Community.java
@@ -13,6 +13,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import javax.validation.constraints.Size;
 import java.util.List;
 
 @Entity
@@ -26,6 +27,7 @@ public class Community {
     @JoinColumn(name = "writer")
     private User writer;
     private String title;
+    @Size(max=2048)
     private String content;
     private String semester;
     private ExType exType;

--- a/src/main/java/com/likelion/boomarble/domain/review/domain/Review.java
+++ b/src/main/java/com/likelion/boomarble/domain/review/domain/Review.java
@@ -11,6 +11,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import javax.validation.constraints.Size;
 import java.util.List;
 
 @Entity
@@ -26,22 +27,33 @@ public class Review {
     private String semester;
     private String dormitoryName;
     private String dormitoryDesc;
+    @Size(max=2048)
     private String admission;
+    @Size(max=2048)
     private String fee;
+    @Size(max=2048)
     private String preparationEtc;
+    @Size(max=2048)
     private String transportation;
+    @Size(max=2048)
     private String enrollment;
+    @Size(max=2048)
     private String program;
     @OneToMany(mappedBy = "review", cascade = CascadeType.ALL)
     @JsonManagedReference
     private List<Subjects> subjects;
+    @Size(max=2048)
     private String activities;
     private String totalCost;
     private String airfare;
     private String insurance;
+    @Size(max=2048)
     private String costEtc;
+    @Size(max=2048)
     private String etc;
+    @Size(max=2048)
     private String acceptedGrade;
+    @Size(max=2048)
     private String message;
     private ExType exType;
     private Country country;

--- a/src/main/java/com/likelion/boomarble/domain/universityInfo/domain/UniversityInfo.java
+++ b/src/main/java/com/likelion/boomarble/domain/universityInfo/domain/UniversityInfo.java
@@ -9,6 +9,7 @@ import org.hibernate.annotations.ColumnDefault;
 import org.springframework.boot.context.properties.bind.DefaultValue;
 
 import javax.persistence.*;
+import javax.validation.constraints.Size;
 import java.util.List;
 
 @Entity
@@ -32,10 +33,13 @@ public class UniversityInfo {
     private float ieltsQ;
     private String japaneseQ;
     private String chineseQ;
+    @Size(max=2048)
     private String qualificationEtc;
     private String expCost;
+    @Size(max=2048)
     private String expCostDesc;
     private String benefit;
+    @Size(max=2048)
     private String etc;
     @OneToMany(mappedBy = "universityInfo") // Review 엔티티의 university 필드와 매핑
     private List<Review> reviews;


### PR DESCRIPTION
### 작업한 내용
- 정보, 리뷰, 커뮤니티에서 길어질 수 있는 필드의 길이를 2048자로 확장했습니다.
