### PR TITLE
Feat: 모의지원 구현

### DIFF
--- a/src/main/java/com/likelion/boomarble/domain/prediction/controller/PredictionController.java
+++ b/src/main/java/com/likelion/boomarble/domain/prediction/controller/PredictionController.java
@@ -40,6 +40,13 @@ public class PredictionController {
         return ResponseEntity.ok(predictionResultDTO);
     }
 
+    @PostMapping("/english")
+    public ResponseEntity applyEnglishPrediction(Authentication authentication, @RequestBody PredictionEnglishInfoDTO predictionEnglishInfoDTO){
+        long userId = getUserPk(authentication);
+        PredictionResultDTO predictionResultDTO = predictionService.applyEnglishPrediction(userId, predictionEnglishInfoDTO);
+        return ResponseEntity.ok(predictionResultDTO);
+    }
+
     public long getUserPk(Authentication authentication){
         CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
         return customUserDetails.getUserPk();

--- a/src/main/java/com/likelion/boomarble/domain/prediction/controller/PredictionController.java
+++ b/src/main/java/com/likelion/boomarble/domain/prediction/controller/PredictionController.java
@@ -1,0 +1,47 @@
+package com.likelion.boomarble.domain.prediction.controller;
+
+import com.likelion.boomarble.domain.prediction.dto.*;
+import com.likelion.boomarble.domain.prediction.service.PredictionService;
+import com.likelion.boomarble.domain.user.domain.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.parameters.P;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/prediction")
+public class PredictionController {
+
+    private final PredictionService predictionService;
+
+    // 영어권인지 비영어권이지 구별하기 위한 컨트롤러
+    @PostMapping("")
+    public ResponseEntity determineRegion(Authentication authentication, @RequestBody BasicInformationDTO basicInformationDTO){
+        String region = predictionService.determineRegionByCountry(basicInformationDTO);
+        return ResponseEntity.ok().body(region);
+    }
+
+    @PostMapping("/japanese")
+    public ResponseEntity applyJapanesePrediction(Authentication authentication, @RequestBody PredictionJapaneseInfoDTO predictionJapaneseInfoDTO){
+        long userId = getUserPk(authentication);
+        PredictionResultDTO predictionResultDTO = predictionService.applyJapanesePrediction(userId, predictionJapaneseInfoDTO);
+        return ResponseEntity.ok(predictionResultDTO);
+    }
+
+    @PostMapping("/chinese")
+    public ResponseEntity applyChinesePrediction(Authentication authentication, @RequestBody PredictionChineseInfoDTO predictionChineseInfoDTO){
+        long userId = getUserPk(authentication);
+        PredictionResultDTO predictionResultDTO = predictionService.applyChinesePrediction(userId, predictionChineseInfoDTO);
+        return ResponseEntity.ok(predictionResultDTO);
+    }
+
+    public long getUserPk(Authentication authentication){
+        CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
+        return customUserDetails.getUserPk();
+    }
+}

--- a/src/main/java/com/likelion/boomarble/domain/prediction/domain/ChinesePrediction.java
+++ b/src/main/java/com/likelion/boomarble/domain/prediction/domain/ChinesePrediction.java
@@ -1,0 +1,34 @@
+package com.likelion.boomarble.domain.prediction.domain;
+
+import com.likelion.boomarble.domain.model.ChineseType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+@Getter
+@AllArgsConstructor @NoArgsConstructor
+public class ChinesePrediction {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+    private ChineseType chineseType;
+    private String testType;
+    private String level;
+    private int score;
+    private double convertedScore;
+
+    @Builder
+    public ChinesePrediction(ChineseType chineseType, String testType, String level, int score, double convertedScore){
+        this.chineseType = chineseType;
+        this.testType = testType;
+        this.level = level;
+        this.score = score;
+        this.convertedScore = convertedScore;
+    }
+}

--- a/src/main/java/com/likelion/boomarble/domain/prediction/domain/EnglishPrediction.java
+++ b/src/main/java/com/likelion/boomarble/domain/prediction/domain/EnglishPrediction.java
@@ -17,11 +17,11 @@ public class EnglishPrediction {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
     private String testType;
-    private int score;
+    private double score;
     private double convertedScore;
 
     @Builder
-    public EnglishPrediction(String testType, int score, double convertedScore){
+    public EnglishPrediction(String testType, double score, double convertedScore){
         this.testType = testType;
         this.score = score;
         this.convertedScore = convertedScore;

--- a/src/main/java/com/likelion/boomarble/domain/prediction/domain/EnglishPrediction.java
+++ b/src/main/java/com/likelion/boomarble/domain/prediction/domain/EnglishPrediction.java
@@ -1,0 +1,29 @@
+package com.likelion.boomarble.domain.prediction.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+@Getter
+@AllArgsConstructor @NoArgsConstructor
+public class EnglishPrediction {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+    private String testType;
+    private int score;
+    private double convertedScore;
+
+    @Builder
+    public EnglishPrediction(String testType, int score, double convertedScore){
+        this.testType = testType;
+        this.score = score;
+        this.convertedScore = convertedScore;
+    }
+}

--- a/src/main/java/com/likelion/boomarble/domain/prediction/domain/JapanesePrediction.java
+++ b/src/main/java/com/likelion/boomarble/domain/prediction/domain/JapanesePrediction.java
@@ -1,0 +1,31 @@
+package com.likelion.boomarble.domain.prediction.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@AllArgsConstructor @NoArgsConstructor
+@Table(indexes = {
+        @Index(name = "idx_score", columnList = "score")
+})
+public class JapanesePrediction {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+    private String level;
+    private int score;
+    private boolean hasRecommendationLetter;
+    private double convertedScore;
+
+    @Builder
+    public JapanesePrediction(String level, int score, boolean hasRecommendationLetter, double convertedScore){
+        this.level = level;
+        this.score = score;
+        this.hasRecommendationLetter = hasRecommendationLetter;
+        this.convertedScore = convertedScore;
+    }
+}

--- a/src/main/java/com/likelion/boomarble/domain/prediction/domain/Prediction.java
+++ b/src/main/java/com/likelion/boomarble/domain/prediction/domain/Prediction.java
@@ -1,41 +1,56 @@
 package com.likelion.boomarble.domain.prediction.domain;
 
+import com.likelion.boomarble.domain.model.Country;
+import com.likelion.boomarble.domain.model.ExType;
 import com.likelion.boomarble.domain.universityInfo.domain.UniversityInfo;
 import com.likelion.boomarble.domain.user.domain.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.lang.Nullable;
 
 import javax.persistence.*;
 
 @Entity
 @Getter
 @AllArgsConstructor @NoArgsConstructor
+@Table(indexes = {
+        @Index(name = "idx_university", columnList = "university")
+})
 public class Prediction {
-
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user")
     private User user;
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "university")
     private UniversityInfo university;
-    private int grade;
-    private int ibt;
-    private int toefl;
-    private int ielts;
+    private double grade;
     private String semester;
+    private Country country;
+    private ExType exType;
+    @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @Nullable
+    private EnglishPrediction englishPrediction;
+    @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @Nullable
+    private JapanesePrediction japanesePrediction;
+    @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @Nullable
+    private ChinesePrediction chinesePrediction;
 
     @Builder
-    public Prediction(User user, UniversityInfo university, int grade, int ibt, int toefl, int ielts, String semester) {
+    public Prediction(User user, UniversityInfo university, double grade, String semester, Country country, ExType exType, EnglishPrediction englishPrediction, JapanesePrediction japanesePrediction, ChinesePrediction chinesePrediction){
         this.user = user;
         this.university = university;
         this.grade = grade;
-        this.ibt = ibt;
-        this.toefl = toefl;
-        this.ielts = ielts;
         this.semester = semester;
+        this.country = country;
+        this.exType = exType;
+        this.englishPrediction = englishPrediction;
+        this.japanesePrediction = japanesePrediction;
+        this.chinesePrediction = chinesePrediction;
     }
 }

--- a/src/main/java/com/likelion/boomarble/domain/prediction/dto/BasicInformationDTO.java
+++ b/src/main/java/com/likelion/boomarble/domain/prediction/dto/BasicInformationDTO.java
@@ -1,0 +1,15 @@
+package com.likelion.boomarble.domain.prediction.dto;
+
+import com.likelion.boomarble.domain.model.Country;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class BasicInformationDTO {
+    private Country country;
+}

--- a/src/main/java/com/likelion/boomarble/domain/prediction/dto/PredictionChineseInfoDTO.java
+++ b/src/main/java/com/likelion/boomarble/domain/prediction/dto/PredictionChineseInfoDTO.java
@@ -1,0 +1,25 @@
+package com.likelion.boomarble.domain.prediction.dto;
+
+import com.likelion.boomarble.domain.model.ChineseType;
+import com.likelion.boomarble.domain.model.Country;
+import com.likelion.boomarble.domain.model.ExType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PredictionChineseInfoDTO {
+    private String semester; // 학기
+    private Country country; // 나라
+    private long universityId; // 대학
+    private ExType exType; // 교환유형
+    private double grade; // 학점
+    private ChineseType chineseType; // 유학 유형
+    private String testType; // 중국어 유형
+    private String level; // 중국어 급수
+    private int score; // 점수
+}

--- a/src/main/java/com/likelion/boomarble/domain/prediction/dto/PredictionEnglishInfoDTO.java
+++ b/src/main/java/com/likelion/boomarble/domain/prediction/dto/PredictionEnglishInfoDTO.java
@@ -18,5 +18,5 @@ public class PredictionEnglishInfoDTO {
     private ExType exType;
     private double grade;
     private String testType;
-    private int score;
+    private double score;
 }

--- a/src/main/java/com/likelion/boomarble/domain/prediction/dto/PredictionEnglishInfoDTO.java
+++ b/src/main/java/com/likelion/boomarble/domain/prediction/dto/PredictionEnglishInfoDTO.java
@@ -1,0 +1,22 @@
+package com.likelion.boomarble.domain.prediction.dto;
+
+import com.likelion.boomarble.domain.model.Country;
+import com.likelion.boomarble.domain.model.ExType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PredictionEnglishInfoDTO {
+    private String semester;
+    private Country country;
+    private int universityId;
+    private ExType exType;
+    private double grade;
+    private String testType;
+    private int score;
+}

--- a/src/main/java/com/likelion/boomarble/domain/prediction/dto/PredictionJapaneseInfoDTO.java
+++ b/src/main/java/com/likelion/boomarble/domain/prediction/dto/PredictionJapaneseInfoDTO.java
@@ -1,0 +1,23 @@
+package com.likelion.boomarble.domain.prediction.dto;
+
+import com.likelion.boomarble.domain.model.Country;
+import com.likelion.boomarble.domain.model.ExType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PredictionJapaneseInfoDTO {
+    private String semester;
+    private Country country;
+    private long universityId;
+    private ExType exType;
+    private double grade;
+    private String level;
+    private int score;
+    private boolean hasRecommendationLetter;
+}

--- a/src/main/java/com/likelion/boomarble/domain/prediction/dto/PredictionResultDTO.java
+++ b/src/main/java/com/likelion/boomarble/domain/prediction/dto/PredictionResultDTO.java
@@ -1,0 +1,18 @@
+package com.likelion.boomarble.domain.prediction.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PredictionResultDTO {
+    private int numOfApplicant; // 총 지원자 수
+    private List<RankScoreDTO> rankings;
+    private List<String> precautions;
+}

--- a/src/main/java/com/likelion/boomarble/domain/prediction/dto/RankScoreDTO.java
+++ b/src/main/java/com/likelion/boomarble/domain/prediction/dto/RankScoreDTO.java
@@ -1,0 +1,17 @@
+package com.likelion.boomarble.domain.prediction.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class RankScoreDTO {
+    private double score;
+    private long rankNum;
+    private long userId;
+    private boolean isUser;
+}

--- a/src/main/java/com/likelion/boomarble/domain/prediction/exception/AlreadyApplyPredictionException.java
+++ b/src/main/java/com/likelion/boomarble/domain/prediction/exception/AlreadyApplyPredictionException.java
@@ -1,0 +1,7 @@
+package com.likelion.boomarble.domain.prediction.exception;
+
+public class AlreadyApplyPredictionException extends RuntimeException{
+    public AlreadyApplyPredictionException(String message){
+        super(message);
+    }
+}

--- a/src/main/java/com/likelion/boomarble/domain/prediction/exception/InvalidScoreException.java
+++ b/src/main/java/com/likelion/boomarble/domain/prediction/exception/InvalidScoreException.java
@@ -1,0 +1,7 @@
+package com.likelion.boomarble.domain.prediction.exception;
+
+public class InvalidScoreException extends RuntimeException{
+    public InvalidScoreException(String message){
+        super(message);
+    }
+}

--- a/src/main/java/com/likelion/boomarble/domain/prediction/exception/NoMoreAvailablePredictionException.java
+++ b/src/main/java/com/likelion/boomarble/domain/prediction/exception/NoMoreAvailablePredictionException.java
@@ -1,0 +1,7 @@
+package com.likelion.boomarble.domain.prediction.exception;
+
+public class NoMoreAvailablePredictionException extends RuntimeException{
+    public NoMoreAvailablePredictionException(String message){
+        super(message);
+    }
+}

--- a/src/main/java/com/likelion/boomarble/domain/prediction/exception/NotAvailableRecommendationLetterException.java
+++ b/src/main/java/com/likelion/boomarble/domain/prediction/exception/NotAvailableRecommendationLetterException.java
@@ -1,0 +1,7 @@
+package com.likelion.boomarble.domain.prediction.exception;
+
+public class NotAvailableRecommendationLetterException extends RuntimeException{
+    public NotAvailableRecommendationLetterException(String message){
+        super(message);
+    }
+}

--- a/src/main/java/com/likelion/boomarble/domain/prediction/exception/RankNotFoundException.java
+++ b/src/main/java/com/likelion/boomarble/domain/prediction/exception/RankNotFoundException.java
@@ -1,0 +1,7 @@
+package com.likelion.boomarble.domain.prediction.exception;
+
+public class RankNotFoundException extends RuntimeException{
+    public RankNotFoundException(String message){
+        super(message);
+    }
+}

--- a/src/main/java/com/likelion/boomarble/domain/prediction/repository/PredictionRepository.java
+++ b/src/main/java/com/likelion/boomarble/domain/prediction/repository/PredictionRepository.java
@@ -27,5 +27,11 @@ public interface PredictionRepository extends JpaRepository<Prediction, Long> {
             "WHERE p.university = :universityId AND p.ex_type = :exType AND cp.chinese_type = :type",
             nativeQuery = true)
     List<Object[]> findChineseRankingsByUniversityId(@Param("universityId") long universityId, @Param("exType") int exType, @Param("type") int chineseType);
+    @Query(value = "SELECT ep.converted_score, ROW_NUMBER() OVER (ORDER BY ep.converted_score DESC) as rankNum, p.user as userId " +
+            "FROM Prediction p " +
+            "LEFT JOIN english_prediction ep ON p.english_prediction_id = ep.id " +
+            "WHERE p.university = :universityId AND p.ex_type = :exType",
+            nativeQuery = true)
+    List<Object[]> findEnglishRankingsByUniversityId(@Param("universityId") long universityId, @Param("exType") int exType);
     Prediction findByUserAndExTypeAndUniversity(User user, ExType exType, UniversityInfo universityInfo);
 }

--- a/src/main/java/com/likelion/boomarble/domain/prediction/repository/PredictionRepository.java
+++ b/src/main/java/com/likelion/boomarble/domain/prediction/repository/PredictionRepository.java
@@ -1,0 +1,31 @@
+package com.likelion.boomarble.domain.prediction.repository;
+
+import com.likelion.boomarble.domain.model.ChineseType;
+import com.likelion.boomarble.domain.model.ExType;
+import com.likelion.boomarble.domain.prediction.domain.Prediction;
+import com.likelion.boomarble.domain.universityInfo.domain.UniversityInfo;
+import com.likelion.boomarble.domain.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface PredictionRepository extends JpaRepository<Prediction, Long> {
+    @Query(value = "SELECT jp.converted_score, ROW_NUMBER() OVER (ORDER BY jp.converted_score DESC) as rankNum, p.user as userId " +
+            "FROM Prediction p " +
+            "LEFT JOIN japanese_prediction jp ON p.japanese_prediction_id = jp.id " +
+            "WHERE p.university = :universityId AND p.ex_type = :exType",
+            nativeQuery = true)
+    List<Object[]> findJapaneseRankingsByUniversityId(@Param("universityId") long universityId, @Param("exType") int exType);
+
+    @Query(value = "SELECT cp.converted_score, ROW_NUMBER() OVER (ORDER BY cp.converted_score DESC) as rankNum, p.user as userId " +
+            "FROM Prediction p " +
+            "LEFT JOIN chinese_prediction cp ON p.chinese_prediction_id = cp.id " +
+            "WHERE p.university = :universityId AND p.ex_type = :exType AND cp.chinese_type = :type",
+            nativeQuery = true)
+    List<Object[]> findChineseRankingsByUniversityId(@Param("universityId") long universityId, @Param("exType") int exType, @Param("type") int chineseType);
+    Prediction findByUserAndExTypeAndUniversity(User user, ExType exType, UniversityInfo universityInfo);
+}

--- a/src/main/java/com/likelion/boomarble/domain/prediction/service/PredictionService.java
+++ b/src/main/java/com/likelion/boomarble/domain/prediction/service/PredictionService.java
@@ -1,9 +1,6 @@
 package com.likelion.boomarble.domain.prediction.service;
 
-import com.likelion.boomarble.domain.prediction.dto.BasicInformationDTO;
-import com.likelion.boomarble.domain.prediction.dto.PredictionChineseInfoDTO;
-import com.likelion.boomarble.domain.prediction.dto.PredictionJapaneseInfoDTO;
-import com.likelion.boomarble.domain.prediction.dto.PredictionResultDTO;
+import com.likelion.boomarble.domain.prediction.dto.*;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -14,4 +11,6 @@ public interface PredictionService {
     PredictionResultDTO applyJapanesePrediction(long userId, PredictionJapaneseInfoDTO predictionJapaneseInfoDTO);
 
     PredictionResultDTO applyChinesePrediction(long userId, PredictionChineseInfoDTO predictionChineseInfoDTO);
+
+    PredictionResultDTO applyEnglishPrediction(long userId, PredictionEnglishInfoDTO predictionEnglishInfoDTO);
 }

--- a/src/main/java/com/likelion/boomarble/domain/prediction/service/PredictionService.java
+++ b/src/main/java/com/likelion/boomarble/domain/prediction/service/PredictionService.java
@@ -1,0 +1,17 @@
+package com.likelion.boomarble.domain.prediction.service;
+
+import com.likelion.boomarble.domain.prediction.dto.BasicInformationDTO;
+import com.likelion.boomarble.domain.prediction.dto.PredictionChineseInfoDTO;
+import com.likelion.boomarble.domain.prediction.dto.PredictionJapaneseInfoDTO;
+import com.likelion.boomarble.domain.prediction.dto.PredictionResultDTO;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface PredictionService {
+
+    String determineRegionByCountry(BasicInformationDTO basicInformationDTO);
+
+    PredictionResultDTO applyJapanesePrediction(long userId, PredictionJapaneseInfoDTO predictionJapaneseInfoDTO);
+
+    PredictionResultDTO applyChinesePrediction(long userId, PredictionChineseInfoDTO predictionChineseInfoDTO);
+}

--- a/src/main/java/com/likelion/boomarble/domain/prediction/service/PredictionServiceImpl.java
+++ b/src/main/java/com/likelion/boomarble/domain/prediction/service/PredictionServiceImpl.java
@@ -1,0 +1,215 @@
+package com.likelion.boomarble.domain.prediction.service;
+
+import com.likelion.boomarble.domain.model.ChineseType;
+import com.likelion.boomarble.domain.model.Country;
+import com.likelion.boomarble.domain.model.ExType;
+import com.likelion.boomarble.domain.prediction.domain.ChinesePrediction;
+import com.likelion.boomarble.domain.prediction.domain.JapanesePrediction;
+import com.likelion.boomarble.domain.prediction.domain.Prediction;
+import com.likelion.boomarble.domain.prediction.dto.*;
+import com.likelion.boomarble.domain.prediction.exception.*;
+import com.likelion.boomarble.domain.prediction.repository.PredictionRepository;
+import com.likelion.boomarble.domain.universityInfo.domain.UniversityInfo;
+import com.likelion.boomarble.domain.universityInfo.exception.UniversityInfoNotFoundException;
+import com.likelion.boomarble.domain.universityInfo.repository.UniversityInfoRepository;
+import com.likelion.boomarble.domain.user.domain.User;
+import com.likelion.boomarble.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PredictionServiceImpl implements PredictionService {
+
+    private final PredictionRepository predictionRepository;
+    private final UserRepository userRepository;
+    private final UniversityInfoRepository universityInfoRepository;
+
+    private static final Map<String, Integer> JLPT_INCREMENTS = Map.of(
+            "N1", 400, "N2", 300, "N3", 200, "N4", 100, "N5", 0
+    );
+    private static final Map<String, Integer> JLPT_MIN_SCORE = Map.of(
+            "N1", 100, "N2", 90, "N3", 95, "N4", 90, "N5", 80
+    );
+    private static final Map<String, Integer> TOCFL_SCORES = Map.of(
+            "1급", 500, "2급", 630, "3급", 840, "4급", 970, "5급", 980, "6급", 990
+    );
+    private static final Map<String, Integer> HSK_INCREMENT = Map.of(
+            "1급", 0, "2급", 190, "3급", 320, "4급", 450, "5급", 540, "6급", 670
+    );
+    private static final Map<String, Integer> HSK_MIN_SCORE = Map.of(
+            "1급", 120, "2급", 120, "3급", 180, "4급", 180, "5급", 180, "6급", 180
+    );
+    @Override
+    @Transactional
+    public String determineRegionByCountry(BasicInformationDTO basicInformationDTO) {
+        Country country = basicInformationDTO.getCountry();
+        if (country.equals("JPN")) return "japanese";
+        if (country.equals("CHN") || country.equals("TWN")) return "chinese";
+        else return "english";
+    }
+
+    /* ##################### 일본 모의지원 관련 ##################### */
+    @Override
+    @Transactional
+    public PredictionResultDTO applyJapanesePrediction(long userId, PredictionJapaneseInfoDTO predictionJapaneseInfoDTO) {
+        // 여러번 호출되는 메서드는 변수로 따로 설정
+        String level;
+        int score;
+        long universityId = predictionJapaneseInfoDTO.getUniversityId();
+        ExType exType = predictionJapaneseInfoDTO.getExType();
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UsernameNotFoundException("해당 유저가 존재하지 않습니다."));
+        if(user.getPredictionCnt() <= 0){
+            throw new NoMoreAvailablePredictionException("모의지원 가능 횟수를 모두 소진하였습니다.");
+        } else user.applyPrediction();
+        UniversityInfo university = universityInfoRepository.findById(universityId)
+                .orElseThrow(() -> new UniversityInfoNotFoundException("해당 대학정보가 존재하지 않습니다."));
+        if(predictionRepository.findByUserAndExTypeAndUniversity(user, exType, university) != null){
+            throw new AlreadyApplyPredictionException("이미 모의지원을 한 대학입니다.");
+        }
+        // 추천서 체크했으면, score이랑 level 업데이트
+        if(predictionJapaneseInfoDTO.isHasRecommendationLetter()){
+            if(university.getQualificationEtc().contains("추천서")){
+                level = university.getJapaneseQ().getJapanese();
+                score = 100;
+            } else throw new NotAvailableRecommendationLetterException("추천서로 대체 가능하지 않습니다.");
+        } else{
+            level = predictionJapaneseInfoDTO.getLevel();
+            score = predictionJapaneseInfoDTO.getScore();
+        }
+        // JLPT 점수가 잘 들어왔는지 확인
+        if(!checkJapaneseScore(level, score)){
+            throw new InvalidScoreException("잘못된 JLPT 점수입니다.");
+        }
+        JapanesePrediction japanesePrediction = JapanesePrediction.builder()
+                .level(level)
+                .score(score)
+                .hasRecommendationLetter(predictionJapaneseInfoDTO.isHasRecommendationLetter())
+                .convertedScore(convertJapaneseScore(level, score)+predictionJapaneseInfoDTO.getGrade()).build();
+        Prediction prediction = Prediction.builder()
+                .user(user)
+                .university(university)
+                .grade(predictionJapaneseInfoDTO.getGrade())
+                .semester(predictionJapaneseInfoDTO.getSemester())
+                .country(predictionJapaneseInfoDTO.getCountry())
+                .exType(exType)
+                .japanesePrediction(japanesePrediction).build();
+        predictionRepository.save(prediction);
+        // 모의지원한 점수가 해당 대학 자격조건에 맞는지 확인
+        List<String> precautions = new ArrayList<>();
+        float universityGrade = university.getGradeQ();
+        String universityJapaneseQ = university.getJapaneseQ().getJapanese();
+        if(universityGrade > predictionJapaneseInfoDTO.getGrade()) precautions.add("학점이 충족되지 않았습니다.");
+        if(universityJapaneseQ != null){
+            if(universityJapaneseQ.compareTo(level)<0) precautions.add("어학성적이 충족되지 않았습니다.");
+        }
+        List<Object[]> results = predictionRepository.findJapaneseRankingsByUniversityId(universityId, exType.ordinal());
+        return getSurroundingPredictions(userId, results, precautions);
+    }
+    // JLPT 점수가 잘 들어왔는지 확인
+    private boolean checkJapaneseScore(String level, int score){
+        return score >= JLPT_MIN_SCORE.getOrDefault(level, 80);
+    }
+    private double convertJapaneseScore(String level, int score){
+        return score + JLPT_INCREMENTS.getOrDefault(level, 0);
+    }
+
+    /* ##################### 중국 모의지원 관련 ##################### */
+    @Override
+    @Transactional
+    public PredictionResultDTO applyChinesePrediction(long userId, PredictionChineseInfoDTO predictionChineseInfoDTO) {
+        // 여러번 호출되는 메서드는 변수로 따로 설정
+        String testType = predictionChineseInfoDTO.getTestType();
+        String level = predictionChineseInfoDTO.getLevel();
+        int score = 0;
+        long universityId = predictionChineseInfoDTO.getUniversityId();
+        ExType exType = predictionChineseInfoDTO.getExType();
+        ChineseType chineseType = predictionChineseInfoDTO.getChineseType();
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UsernameNotFoundException("해당 유저가 존재하지 않습니다."));
+        if(user.getPredictionCnt() <= 0){
+            throw new NoMoreAvailablePredictionException("모의지원 가능 횟수를 모두 소진하였습니다.");
+        } else user.applyPrediction();
+        UniversityInfo university = universityInfoRepository.findById(universityId)
+                .orElseThrow(() -> new UniversityInfoNotFoundException("해당 대학정보가 존재하지 않습니다."));
+        if(predictionRepository.findByUserAndExTypeAndUniversity(user, exType, university) != null){
+            throw new AlreadyApplyPredictionException("이미 모의지원을 한 대학입니다.");
+        }
+        if(testType.equals("HSK")){
+            score = predictionChineseInfoDTO.getScore();
+            if(!checkChineseScore(level, score)) throw new InvalidScoreException("잘못된 HSK 점수입니다.");
+        }
+        ChinesePrediction chinesePrediction = ChinesePrediction.builder()
+                .chineseType(chineseType)
+                .testType(testType)
+                .level(level)
+                .score(score)
+                .convertedScore(convertChineseScore(testType, level, score)+predictionChineseInfoDTO.getGrade()).build();
+        Prediction prediction = Prediction.builder()
+                .user(user)
+                .university(university)
+                .grade(predictionChineseInfoDTO.getGrade())
+                .semester(predictionChineseInfoDTO.getSemester())
+                .country(predictionChineseInfoDTO.getCountry())
+                .exType(exType)
+                .chinesePrediction(chinesePrediction).build();
+        predictionRepository.save(prediction);
+        List<String> precautions = new ArrayList<>();
+        float universityGrade = university.getGradeQ();
+        if(universityGrade > predictionChineseInfoDTO.getGrade()) precautions.add("학점이 충족되지 않았습니다.");
+        List<Object[]> results = predictionRepository.findChineseRankingsByUniversityId(universityId, exType.ordinal(), chineseType.ordinal());
+        return getSurroundingPredictions(userId, results, precautions);
+    }
+    // HSK 점수가 잘 들어왔는지 확인
+    private boolean checkChineseScore(String level, int score){
+        return score >= HSK_MIN_SCORE.getOrDefault(level, 180);
+    }
+    private double convertChineseScore(String testType, String level, int score){
+        if(testType.equals("TOCFL")) return TOCFL_SCORES.getOrDefault(level, 990);
+        else return score + HSK_INCREMENT.getOrDefault(level, 0);
+    }
+    // 같은 대학교에 지원한 사람들끼리 순위를 매겨서 자신의 순위와 자신보다 앞에 두 사람과 뒤에 두 사람 점수 같이 반환
+    private PredictionResultDTO getSurroundingPredictions(long userId, List<Object[]> results, List<String> precautions) {
+        List<RankScoreDTO> rankings = results.stream()
+                .map(result -> convertToRankScoreDTO(result, userId))
+                .collect(Collectors.toList());
+        RankScoreDTO userRanking = findUserRanking(rankings, userId);
+        List<RankScoreDTO> surroundingRankings = findSurroundingRankings(rankings, userRanking.getRankNum());
+        return PredictionResultDTO.builder()
+                .numOfApplicant(rankings.size())
+                .rankings(surroundingRankings)
+                .precautions(precautions)
+                .build();
+    }
+    private RankScoreDTO convertToRankScoreDTO(Object[] result, long userId) {
+        long resultUserId = ((BigInteger) result[2]).longValue();
+        return new RankScoreDTO(
+                (Double) result[0],
+                ((BigInteger) result[1]).longValue(),
+                resultUserId,
+                resultUserId == userId
+        );
+    }
+    // 본인의 등수 찾기
+    private RankScoreDTO findUserRanking(List<RankScoreDTO> rankings, long userId) {
+        return rankings.stream()
+                .filter(r -> r.getUserId() == userId)
+                .findFirst()
+                .orElseThrow(() -> new RankNotFoundException("사용자 순위를 찾을 수 없습니다."));
+    }
+    // 자신보다 앞 순위 두명과 뒷 순위 두명 찾기
+    private List<RankScoreDTO> findSurroundingRankings(List<RankScoreDTO> rankings, long userRank) {
+        return rankings.stream()
+                .filter(r -> Math.abs(r.getRankNum() - userRank) <= 2)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/likelion/boomarble/domain/prediction/service/PredictionServiceImpl.java
+++ b/src/main/java/com/likelion/boomarble/domain/prediction/service/PredictionServiceImpl.java
@@ -4,6 +4,7 @@ import com.likelion.boomarble.domain.model.ChineseType;
 import com.likelion.boomarble.domain.model.Country;
 import com.likelion.boomarble.domain.model.ExType;
 import com.likelion.boomarble.domain.prediction.domain.ChinesePrediction;
+import com.likelion.boomarble.domain.prediction.domain.EnglishPrediction;
 import com.likelion.boomarble.domain.prediction.domain.JapanesePrediction;
 import com.likelion.boomarble.domain.prediction.domain.Prediction;
 import com.likelion.boomarble.domain.prediction.dto.*;
@@ -20,10 +21,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
+
+import static java.util.Map.entry;
 
 @Service
 @RequiredArgsConstructor
@@ -48,6 +49,29 @@ public class PredictionServiceImpl implements PredictionService {
     private static final Map<String, Integer> HSK_MIN_SCORE = Map.of(
             "1급", 120, "2급", 120, "3급", 180, "4급", 180, "5급", 180, "6급", 180
     );
+    private static final NavigableMap<Integer, Integer> TOEFL_TO_IBT = new TreeMap<>(Map.ofEntries(
+            entry(673, 120), entry(670, 119), entry(667, 118), entry(660, 117), entry(657, 116),
+            entry(650, 115), entry(647, 113), entry(640, 112), entry(637, 110), entry(630, 109),
+            entry(623, 108), entry(617, 105), entry(613, 104), entry(607, 102), entry(600, 100),
+            entry(597, 99), entry(590, 97), entry(587, 95), entry(580, 93), entry(577, 91),
+            entry(570, 89), entry(567, 87), entry(563, 85), entry(557, 83), entry(553, 82),
+            entry(550, 80), entry(547, 78), entry(540, 76), entry(537, 75), entry(533, 73),
+            entry(527, 71), entry(523, 70), entry(520, 68), entry(517, 67), entry(513, 65),
+            entry(507, 64), entry(503, 63), entry(500, 61), entry(497, 60), entry(493, 58),
+            entry(487, 57), entry(483, 56), entry(480, 55), entry(477, 53), entry(470, 52),
+            entry(467, 51), entry(463, 50), entry(460, 48), entry(457, 47), entry(450, 46),
+            entry(447, 44), entry(443, 43), entry(437, 42), entry(433, 40), entry(430, 39),
+            entry(423, 38), entry(420, 37), entry(417, 35), entry(410, 34), entry(407, 33),
+            entry(400, 32), entry(397, 31), entry(390, 29), entry(387, 28), entry(380, 27),
+            entry(377, 25), entry(370, 24), entry(363, 23), entry(357, 22), entry(353, 21),
+            entry(347, 20), entry(340, 18), entry(333, 17), entry(330, 16), entry(323, 15),
+            entry(317, 14), entry(313, 13), entry(310, 12)
+    ));
+    private static final NavigableMap<Double, Integer> IELTS_TO_IBT = new TreeMap<>(Map.ofEntries(
+            entry(9.0, 120), entry(8.5, 117), entry(8.0, 114), entry(7.5, 109), entry(7.0, 101),
+            entry(6.5, 93), entry(6.0, 78), entry(5.5, 59), entry(5.0, 45), entry(4.5, 34), entry(0.0, 31)
+    ));
+
     @Override
     @Transactional
     public String determineRegionByCountry(BasicInformationDTO basicInformationDTO) {
@@ -163,6 +187,7 @@ public class PredictionServiceImpl implements PredictionService {
                 .exType(exType)
                 .chinesePrediction(chinesePrediction).build();
         predictionRepository.save(prediction);
+        // 모의지원한 점수가 해당 대학 자격조건에 맞는지 확인
         List<String> precautions = new ArrayList<>();
         float universityGrade = university.getGradeQ();
         if(universityGrade > predictionChineseInfoDTO.getGrade()) precautions.add("학점이 충족되지 않았습니다.");
@@ -177,6 +202,65 @@ public class PredictionServiceImpl implements PredictionService {
         if(testType.equals("TOCFL")) return TOCFL_SCORES.getOrDefault(level, 990);
         else return score + HSK_INCREMENT.getOrDefault(level, 0);
     }
+
+    /* ##################### 영어 모의지원 관련 ##################### */
+    @Override
+    @Transactional
+    public PredictionResultDTO applyEnglishPrediction(long userId, PredictionEnglishInfoDTO predictionEnglishInfoDTO) {
+        // 여러번 호출되는 메서드는 변수로 따로 설정
+        String testType = predictionEnglishInfoDTO.getTestType();
+        double score = predictionEnglishInfoDTO.getScore();
+        long universityId = predictionEnglishInfoDTO.getUniversityId();
+        ExType exType = predictionEnglishInfoDTO.getExType();
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UsernameNotFoundException("해당 유저가 존재하지 않습니다."));
+        if(user.getPredictionCnt() <= 0){
+            throw new NoMoreAvailablePredictionException("모의지원 가능 횟수를 모두 소진하였습니다.");
+        } else user.applyPrediction();
+        UniversityInfo university = universityInfoRepository.findById(universityId)
+                .orElseThrow(() -> new UniversityInfoNotFoundException("해당 대학정보가 존재하지 않습니다."));
+        if(predictionRepository.findByUserAndExTypeAndUniversity(user, exType, university) != null){
+            throw new AlreadyApplyPredictionException("이미 모의지원을 한 대학입니다.");
+        }
+        EnglishPrediction englishPrediction = EnglishPrediction.builder()
+                .testType(testType)
+                .score(score)
+                .convertedScore(convertEnglishScore(testType, score)+predictionEnglishInfoDTO.getGrade()).build();
+        Prediction prediction = Prediction.builder()
+                .user(user)
+                .university(university)
+                .grade(predictionEnglishInfoDTO.getGrade())
+                .semester(predictionEnglishInfoDTO.getSemester())
+                .country(predictionEnglishInfoDTO.getCountry())
+                .exType(exType)
+                .englishPrediction(englishPrediction).build();
+        predictionRepository.save(prediction);
+        // 모의지원한 점수가 해당 대학 자격조건에 맞는지 확인
+        List<String> precautions = new ArrayList<>();
+        float universityGrade = university.getGradeQ();
+        if(universityGrade > predictionEnglishInfoDTO.getGrade()) precautions.add("학점이 충족되지 않았습니다.");
+        if(!satisfyEnglishScore(university, testType, score)) precautions.add("어학 성적이 충족되지 않았습니다.");
+        List<Object[]> results = predictionRepository.findEnglishRankingsByUniversityId(universityId, exType.ordinal());
+        return getSurroundingPredictions(userId, results, precautions);
+    }
+    private boolean satisfyEnglishScore(UniversityInfo university, String testType, double score){
+        if(testType.equals("IELTS")){
+            if(university.getEnglishQ().getIeltsQ() == -1) throw new InvalidScoreException("IELTS는 필수 어학 성적이 아닙니다.");
+            else return university.getEnglishQ().getIeltsQ() <= score;
+        } else if(testType.equals("TOEFL")){
+            if(university.getEnglishQ().getToefl() == -1) throw new InvalidScoreException("TOEFL는 필수 어학 성적이 아닙니다.");
+            else return university.getEnglishQ().getToefl() <= score;
+        } else{
+            if(university.getEnglishQ().getIbtQ() == -1) throw new InvalidScoreException("IBT는 필수 어학 성적이 아닙니다.");
+            else return university.getEnglishQ().getIbtQ() <= score;
+        }
+    }
+    private double convertEnglishScore(String testType, double score){
+        if(testType.equals("IELTS")) return IELTS_TO_IBT.floorEntry(score).getValue();
+        else if(testType.equals("TOEFL")) return TOEFL_TO_IBT.floorEntry((int)score).getValue();
+        else return score;
+    }
+
     // 같은 대학교에 지원한 사람들끼리 순위를 매겨서 자신의 순위와 자신보다 앞에 두 사람과 뒤에 두 사람 점수 같이 반환
     private PredictionResultDTO getSurroundingPredictions(long userId, List<Object[]> results, List<String> precautions) {
         List<RankScoreDTO> rankings = results.stream()

--- a/src/main/java/com/likelion/boomarble/domain/universityInfo/service/UniversityInfoServiceImpl.java
+++ b/src/main/java/com/likelion/boomarble/domain/universityInfo/service/UniversityInfoServiceImpl.java
@@ -44,7 +44,7 @@ public class UniversityInfoServiceImpl implements UniversityInfoService{
     @Transactional
     public UniversityInfoDetailDTO getUniversityInfoDetail(long universityId) {
         UniversityInfo universityInfo = universityInfoRepository.findById(universityId)
-                .orElseThrow(() -> new UniversityInfoNotFoundException("해당 대학 정보가 없습니다."));
+                .orElseThrow(() -> new UniversityInfoNotFoundException("해당 대학정보가 존재하지 않습니다."));
         return UniversityInfoDetailDTO.from(universityInfo);
     }
     @Override

--- a/src/main/java/com/likelion/boomarble/domain/user/domain/User.java
+++ b/src/main/java/com/likelion/boomarble/domain/user/domain/User.java
@@ -20,6 +20,7 @@ public class User {
     private String major1;
     private String major2;
     private String studentId;
+    private int predictionCnt;
 
     @Enumerated(EnumType.STRING)
     private Role role;
@@ -39,5 +40,12 @@ public class User {
 
     public void encodePassword(PasswordEncoder passwordEncoder) {
         this.password = passwordEncoder.encode(password);
+    }
+
+    public void applyPrediction(){ this.predictionCnt-=1;}
+
+    @PrePersist
+    public void setPredictionCnt() {
+        this.predictionCnt = 3;
     }
 }

--- a/src/main/java/com/likelion/boomarble/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/likelion/boomarble/global/error/GlobalExceptionHandler.java
@@ -1,4 +1,5 @@
 package com.likelion.boomarble.global.error;
+import com.likelion.boomarble.domain.prediction.exception.InvalidScoreException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.http.ResponseEntity;
@@ -12,5 +13,10 @@ public class GlobalExceptionHandler {
     public ResponseEntity<?> handleTypeMismatchException(MethodArgumentTypeMismatchException ex) {
         String message = "유효하지 않은 값: " + ex.getValue() + ". " + ex.getName() + "은(는) 유효한 값을 제공해야 합니다.";
         return new ResponseEntity<>(message, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(InvalidScoreException.class)
+    public ResponseEntity<Object> handleInvalidJapaneseScoreException(InvalidScoreException ex) {
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
     }
 }


### PR DESCRIPTION
### 작업한 내용
- 영어권 + 비영어권 모의지원을 구현했습니다.
- 모의지원을 하게 되면, 전체 지원자 수와 (모의지원을 한)유저의 등수/점수, 유저보다 앞 순위 두명과 뒷 순위 두명의 점수를 같이 반환합니다.
- 모의지원 관련 자세한 내용은 노션에 정리해놨습니다!

### 추후 작업할 내용
- 채팅 구현
