### PR TITLE
Feat:댓글 수정 삭제 기능 추가

### DIFF
--- a/src/main/java/com/likelion/boomarble/domain/community/controller/CommunityController.java
+++ b/src/main/java/com/likelion/boomarble/domain/community/controller/CommunityController.java
@@ -36,7 +36,7 @@ public class CommunityController  {
         long userId = getUserPk(authentication);
         Community result = communityService.createCommunityPost(userId, communityCreateDTO);
         if (result == null) return ResponseEntity.badRequest().build();
-        else return ResponseEntity.ok("커뮤니티 글이 정상적으로 등록되었습니다.");
+        else return ResponseEntity.ok("커뮤니티 글이 정상적으로 등록되었습니다. id: " + result.getId());
     }
 
     @GetMapping("")
@@ -56,7 +56,7 @@ public class CommunityController  {
         return ResponseEntity.ok(communityDetailDTO);
     }
 
-    //댓글
+    //comment
     @PostMapping("/{postId}/comments")
     public ResponseEntity createComment(
             Authentication authentication,
@@ -66,7 +66,7 @@ public class CommunityController  {
         commentRequestDTO.setUserId(userId);
         Comment result = commentService.createComment(postId, commentRequestDTO);
         if (result == null) return ResponseEntity.badRequest().build();
-        else return ResponseEntity.ok("댓글이 정상적으로 등록되었습니다.");
+        else return ResponseEntity.ok("댓글이 정상적으로 등록되었습니다. id: " + result.getId());
     }
 
     @GetMapping("/{postId}/comments")
@@ -75,6 +75,22 @@ public class CommunityController  {
         return ResponseEntity.ok(commentList);
     }
 
+    @PutMapping("/{postId}/comments/{commentId}")
+    public ResponseEntity updateComment(
+            Authentication authentication,
+            @PathVariable long commentId,
+            @RequestBody CommentRequestDTO commentRequestDTO){
+            commentService.update(commentId, commentRequestDTO);
+            return ResponseEntity.ok("댓글이 수정되었습니다. id: " + commentId);
+    }
+
+    @DeleteMapping("/{postId}/comments/{commentId}")
+    public ResponseEntity deleteComment(Authentication authentication, @PathVariable long commentId){
+        commentService.delete(commentId);
+        return ResponseEntity.ok("댓글이 삭제되었습니다. id: " + commentId);
+    }
+
+    //scrap
     @PostMapping("/{postId}/scrap")
     public ResponseEntity scrapCommunity(
             Authentication authentication,
@@ -83,8 +99,8 @@ public class CommunityController  {
         long userId = getUserPk(authentication);
         int result = communityService.scrapReview(postId, userId);
         if (result == 400) return ResponseEntity.badRequest().body("잘못된 요청입니다.");
-        else if (result == 409) return ResponseEntity.badRequest().body("이미 스크랩되었습니다.");
-        return ResponseEntity.ok("스크랩 완료되었습니다.");
+        else if (result == 409) return ResponseEntity.badRequest().body("이미 스크랩되었습니다. id: " + postId);
+        return ResponseEntity.ok("스크랩 완료되었습니다. id: " + postId);
     }
 
     @DeleteMapping("/{postId}/scrap")
@@ -95,8 +111,8 @@ public class CommunityController  {
         long userId = getUserPk(authentication);
         int result = communityService.unscrapReview(postId, userId);
         if (result == 400) return ResponseEntity.badRequest().body("잘못된 요청입니다.");
-        else if (result == 404) return ResponseEntity.badRequest().body("스크랩한 기록이 없습니다.");
-        return ResponseEntity.ok("스크랩이 정상적으로 취소되었습니다.");
+        else if (result == 404) return ResponseEntity.badRequest().body("스크랩한 기록이 없습니다. id: " + postId);
+        return ResponseEntity.ok("스크랩이 정상적으로 취소되었습니다. id: " + postId);
     }
 
 }

--- a/src/main/java/com/likelion/boomarble/domain/community/domain/Comment.java
+++ b/src/main/java/com/likelion/boomarble/domain/community/domain/Comment.java
@@ -34,7 +34,7 @@ public class Comment extends BaseTimeEntity {
     @JoinColumn(name = "parent_id")
     private Comment parent;
 
-    @OneToMany(mappedBy = "parent", orphanRemoval = true)
+    @OneToMany(mappedBy = "parent", orphanRemoval = true) //부모 댓글이 삭제되면 자식 댓글도 삭제
     private List<Comment> children = new ArrayList<>();
 
     @ManyToOne
@@ -61,5 +61,7 @@ public class Comment extends BaseTimeEntity {
         this.isDeleted = isDeleted;
     }
 
-
+    public void updateContent(String content) {
+        this.content = content;
+    }
 }

--- a/src/main/java/com/likelion/boomarble/domain/community/repository/CommentCustomRepository.java
+++ b/src/main/java/com/likelion/boomarble/domain/community/repository/CommentCustomRepository.java
@@ -8,5 +8,5 @@ import java.util.Optional;
 
 public interface CommentCustomRepository {
     List<CommentResponseDTO> findByBoardId(Long id);
-    Optional<Comment> findCommentByIdWithParent(Long id);
+    Optional<Comment> findCommentByBIdWithParent(Long id);
 }

--- a/src/main/java/com/likelion/boomarble/domain/community/repository/CommentRepository.java
+++ b/src/main/java/com/likelion/boomarble/domain/community/repository/CommentRepository.java
@@ -1,12 +1,8 @@
 package com.likelion.boomarble.domain.community.repository;
 
 import com.likelion.boomarble.domain.community.domain.Comment;
-import com.likelion.boomarble.domain.community.dto.CommentResponseDTO;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-
 @Repository
-public interface CommentRepository extends JpaRepository<Comment, Long>, CommentCustomRepository {
-}
+public interface CommentRepository extends JpaRepository<Comment, Long>, CommentCustomRepository {}

--- a/src/main/java/com/likelion/boomarble/domain/community/repository/CommentRepositoryImpl.java
+++ b/src/main/java/com/likelion/boomarble/domain/community/repository/CommentRepositoryImpl.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Repository;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import javax.persistence.Query;
 import java.util.*;
 
 import static com.likelion.boomarble.domain.community.dto.CommentResponseDTO.convertCommentToDto;
@@ -48,7 +49,15 @@ public class CommentRepositoryImpl implements CommentCustomRepository{
     }
 
     @Override
-    public Optional<Comment> findCommentByIdWithParent(Long id) {
-        return Optional.empty();
+    public Optional<Comment> findCommentByBIdWithParent(Long id) {
+        String jpql =   "SELECT c FROM Comment c " +
+                        "LEFT JOIN FETCH c.parent " +
+                        "WHERE c.id = :id";
+        Query query = entityManager.createQuery(jpql, Comment.class);
+        query.setParameter("id", id);
+
+        Comment selectedComment = (Comment) query.getSingleResult();
+
+        return Optional.ofNullable(selectedComment);
     }
 }

--- a/src/main/java/com/likelion/boomarble/domain/community/service/CommentService.java
+++ b/src/main/java/com/likelion/boomarble/domain/community/service/CommentService.java
@@ -9,5 +9,7 @@ import java.util.List;
 public interface CommentService {
     Comment createComment(Long postId, CommentRequestDTO commentRequestDTO);
     List<CommentResponseDTO> findCommentsByPostId(Long postId);
-
+    void update(Long commentId, CommentRequestDTO commentRequestDTO);
+    void delete(Long commentId);
+    Comment getDeletableAncestorComment(Comment comment);
 }

--- a/src/main/java/com/likelion/boomarble/domain/community/service/CommentServiceImpl.java
+++ b/src/main/java/com/likelion/boomarble/domain/community/service/CommentServiceImpl.java
@@ -13,9 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -55,16 +53,33 @@ public class CommentServiceImpl implements CommentService {
         return commentRepository.findByBoardId(postId);
     }
 
-//    @Transactional
-//    public List<CommentResponseDTO> getCommentsByPostId(Long postId) {
-//        List<Comment> commentsByPost = commentRepository.findAllByCommunity(postId);
-//        List<CommentResponseDTO> fullComments = new ArrayList<>();
-//        for (Comment comment: commentsByPost){
-//            if (comment.getParent() == null) {
-//                new CommentResponseDTO(comment.getContent(), comment.getWriter())
-//                fullComments.add(parentComment);
-//            }
-//        }
-//        return
-//    }
+    @Override
+    @Transactional
+    public void update(Long commentId, CommentRequestDTO commentRequestDTO) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new NotFoundException("해당 댓글을 찾을 수 없습니다. id: " + commentId));
+        comment.updateContent(commentRequestDTO.getContent());
+    }
+
+    @Override
+    @Transactional
+    public void delete(Long commentId) {
+        Comment comment = commentRepository.findCommentByBIdWithParent(commentId)
+                .orElseThrow(() -> new NotFoundException("해당 댓글을 찾을 수 없습니다. id: " + commentId));
+        if(comment.getChildren().size() != 0){  //자식이 있으면 상태만 변경
+            comment.changeIsDeleted(true);
+        } else {                                //삭제 가능한 조상 댓글을 찾아서 삭제
+            commentRepository.delete(getDeletableAncestorComment(comment));
+        }
+    }
+
+    @Override
+    @Transactional
+    public Comment getDeletableAncestorComment(Comment comment) {
+        Comment parent = comment.getParent();   //현재 댓글의 부모를 구함
+        if (parent != null && parent.getChildren().size() == 1 && parent.getIsDeleted())
+            //부모가 있고, 부모의 자식이 1개(지금 삭제하는 댓글)이고, 부모의 삭제 상태가 TRUE인 댓글이라면 재귀
+            return getDeletableAncestorComment(parent);
+        return comment;
+    }
 }

--- a/src/main/java/com/likelion/boomarble/domain/community/service/CommunityServiceImpl.java
+++ b/src/main/java/com/likelion/boomarble/domain/community/service/CommunityServiceImpl.java
@@ -42,18 +42,6 @@ public class CommunityServiceImpl implements CommunityService {
 
     @Override
     @Transactional
-    public CommunityListDTO getCommunityList(Country country, String university, ExType type, String semester) {
-        Specification<Community> spec = Specification.where(CommunitySpecification.hasCountry(country))
-                .and(CommunitySpecification.hasUniversity(university))
-                .and(CommunitySpecification.hasType(type))
-                .and(CommunitySpecification.hasSemester(semester));
-
-        List<Community> communities = communityRepository.findAll(spec);
-        return CommunityListDTO.from(communities);
-    }
-
-    @Override
-    @Transactional
     public Community createCommunityPost(Long userId, CommunityCreateDTO communityCreateDTO) {
         Optional<User> user = userRepository.findById(userId);
         long universityId = communityCreateDTO.getPostUniversityId();
@@ -70,10 +58,11 @@ public class CommunityServiceImpl implements CommunityService {
         // 태그에 학기, 대학, 나라, 교환유형 추가
         ArrayList<String> tagList = new ArrayList(
                 Arrays.asList(communityCreateDTO.getPostTags().split(",")));
-        if(semester != null) { tagList.add(semester); }
-        if(university != null) { tagList.add(university.getName()); }
-        if(country != null) { tagList.add(country.getName()); }
-        if(exType != null) { tagList.add(exType.getName()); }
+
+        if(university != null) { tagList.add(0, university.getName()); }
+        if(country != null) { tagList.add(0, country.getName()); }
+        if(exType != null) { tagList.add(0, exType.getName()); }
+        if(semester != null) { tagList.add(0, semester); }
 
         // 해시태그 추가
         for(String tag : tagList){
@@ -89,6 +78,18 @@ public class CommunityServiceImpl implements CommunityService {
             communityTagRepository.save(communityTagMap);
         }
         return result;
+    }
+
+    @Override
+    @Transactional
+    public CommunityListDTO getCommunityList(Country country, String university, ExType type, String semester) {
+        Specification<Community> spec = Specification.where(CommunitySpecification.hasCountry(country))
+                .and(CommunitySpecification.hasUniversity(university))
+                .and(CommunitySpecification.hasType(type))
+                .and(CommunitySpecification.hasSemester(semester));
+
+        List<Community> communities = communityRepository.findAll(spec);
+        return CommunityListDTO.from(communities);
     }
 
     @Override
@@ -112,7 +113,9 @@ public class CommunityServiceImpl implements CommunityService {
         return tagList;
     }
 
+    // Scrap
     @Override
+    @Transactional
     public int scrapReview(long postId, long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UsernameNotFoundException("해당 유저가 존재하지 않습니다."));
@@ -124,6 +127,7 @@ public class CommunityServiceImpl implements CommunityService {
     }
 
     @Override
+    @Transactional
     public int unscrapReview(long postId, long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UsernameNotFoundException("해당 유저가 존재하지 않습니다."));


### PR DESCRIPTION
### 작업한 내용
- 댓글 수정, 삭제 기능을 추가했습니다. 
- 대댓글이 있는 경우, 원댓글을 삭제하지 않고 대댓글을 삭제할 때 원댓글이 삭제된 상태라면 같이 삭제되도록 했습니다. 

### 논의할 내용
- url을 설정할 때, 사용하지 않는 변수를 포함하지 않는게 좋은지 or 구조상 이해하기 쉬운 url로 작성하는 것이 좋은지 궁금합니다.
> ex. `@PutMapping("posts/{postId}/comments/{commentId}") `  -> 여기서 postId는 사용하지 않는데, 이를 comments/{commentId}로 구분하는 것이 좋은지, 해당 게시글에 달린 댓글이니 의미상 기존 url을 유지하는 것이 좋은지 궁금합니다!

### 추후 작업할 내용
- 댓글 수정, 삭제 기능은 댓글 작성자 한정으로 하는 방법을 고민하고 있습니다.
- 소셜 로그인 구현할 예정입니다.
