### PR TITLE
Feat: tagList 관련 코드 수정, 커뮤니티 글 검색 기능 추가

### DIFF
--- a/src/main/java/com/likelion/boomarble/domain/community/controller/CommunityController.java
+++ b/src/main/java/com/likelion/boomarble/domain/community/controller/CommunityController.java
@@ -76,6 +76,13 @@ public class CommunityController  {
         return ResponseEntity.ok("게시글이 정상적으로 삭제되었습니다. id: " + postId);
     }
 
+    @GetMapping("/search")
+    public ResponseEntity searchCommunityPost(
+            @RequestParam(value="keyword") String keyword){
+        List<CommunitySearchDTO> searchDTOList = communityService.getCommunitySearch(keyword);
+        return ResponseEntity.ok(searchDTOList);
+    }
+
     //comment
     @PostMapping("/{postId}/comments")
     public ResponseEntity createComment(

--- a/src/main/java/com/likelion/boomarble/domain/community/domain/Community.java
+++ b/src/main/java/com/likelion/boomarble/domain/community/domain/Community.java
@@ -60,5 +60,4 @@ public class Community {
     public void setCommunityTagList(List<String> communityTagList) {
         this.communityTagList = communityTagList;
     }
-
 }

--- a/src/main/java/com/likelion/boomarble/domain/community/domain/Community.java
+++ b/src/main/java/com/likelion/boomarble/domain/community/domain/Community.java
@@ -12,7 +12,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
-import javax.validation.constraints.Size;
 import java.util.List;
 
 @Entity
@@ -31,12 +30,14 @@ public class Community {
     private String semester;
     private ExType exType;
     private Country country;
+    @ElementCollection
+    private List<String> communityTagList;
     @ManyToOne
     @JoinColumn(name = "university")
     private UniversityInfo university;
     @JsonIgnore
     @OneToMany(mappedBy = "community", cascade = {CascadeType.ALL}, orphanRemoval = true)
-    private List<CommunityTagMap> communityTagList;
+    private List<CommunityTagMap> communityTagMapList;
     @JsonIgnore
     @OneToMany(mappedBy = "community", cascade = {CascadeType.ALL}, orphanRemoval = true)
     private List<Comment> commentList;
@@ -56,5 +57,8 @@ public class Community {
         this.content = content;
     }
 
+    public void setCommunityTagList(List<String> communityTagList) {
+        this.communityTagList = communityTagList;
+    }
 
 }

--- a/src/main/java/com/likelion/boomarble/domain/community/dto/CommunityDetailDTO.java
+++ b/src/main/java/com/likelion/boomarble/domain/community/dto/CommunityDetailDTO.java
@@ -21,13 +21,13 @@ public class CommunityDetailDTO {
     private String content;
     private List<String> communityTagList;
 
-    public static CommunityDetailDTO from(Community community, List<String> communityTagList) {
+    public static CommunityDetailDTO from(Community community) {
 
         return CommunityDetailDTO.builder()
                 .communityWriter(community.getWriter())
                 .title(community.getTitle())
                 .content(community.getContent())
-                .communityTagList(communityTagList)
+                .communityTagList(community.getCommunityTagList())
                 .build();
     }
 }

--- a/src/main/java/com/likelion/boomarble/domain/community/dto/CommunitySearchDTO.java
+++ b/src/main/java/com/likelion/boomarble/domain/community/dto/CommunitySearchDTO.java
@@ -1,7 +1,6 @@
 package com.likelion.boomarble.domain.community.dto;
 
 import com.likelion.boomarble.domain.community.domain.Community;
-import com.likelion.boomarble.domain.user.domain.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,16 +12,15 @@ import java.util.List;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class CommunityDetailDTO {
-    private User communityWriter;
+public class CommunitySearchDTO {
+    private String writerNickname;
     private String title;
     private String content;
     private List<String> communityTagList;
 
-    public static CommunityDetailDTO from(Community community) {
-
-        return CommunityDetailDTO.builder()
-                .communityWriter(community.getWriter())
+    public static CommunitySearchDTO from(Community community) {
+        return CommunitySearchDTO.builder()
+                .writerNickname(community.getWriter().getNickname())
                 .title(community.getTitle())
                 .content(community.getContent())
                 .communityTagList(community.getCommunityTagList())

--- a/src/main/java/com/likelion/boomarble/domain/community/dto/CommunityViewDTO.java
+++ b/src/main/java/com/likelion/boomarble/domain/community/dto/CommunityViewDTO.java
@@ -1,7 +1,6 @@
 package com.likelion.boomarble.domain.community.dto;
 
 import com.likelion.boomarble.domain.community.domain.Community;
-import com.likelion.boomarble.domain.model.Tag;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,7 +12,7 @@ import java.util.List;
 @AllArgsConstructor @NoArgsConstructor
 public class CommunityViewDTO {
     private String communityTitle;
-    private List<CommunityTagMap> communityTagList;
+    private List<String> communityTagList;
 
     public static CommunityViewDTO of (Community community) {
         return CommunityViewDTO.builder()

--- a/src/main/java/com/likelion/boomarble/domain/community/repository/CommunityRepository.java
+++ b/src/main/java/com/likelion/boomarble/domain/community/repository/CommunityRepository.java
@@ -6,9 +6,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface CommunityRepository extends JpaRepository<Community, Long>, JpaSpecificationExecutor<Community> {
     Optional<Community> findByIdAndWriter(Long postId, User user);
+    List<Community> findByTitleContaining(String keyword);
+    List<Community> findByContentContaining(String keyword);
+    List<Community> findByCommunityTagListContaining(String keyword);
 }

--- a/src/main/java/com/likelion/boomarble/domain/community/service/CommunityService.java
+++ b/src/main/java/com/likelion/boomarble/domain/community/service/CommunityService.java
@@ -5,12 +5,15 @@ import com.likelion.boomarble.domain.community.dto.*;
 import com.likelion.boomarble.domain.model.Country;
 import com.likelion.boomarble.domain.model.ExType;
 
+import java.util.List;
+
 public interface CommunityService {
     Community createCommunityPost(Long userId, CommunityCreateDTO communityCreateDTO);
     CommunityListDTO getCommunityList(Country country, String university, ExType type, String semester);
     CommunityDetailDTO getCommunityDetail(long postId);
     int updateCommunityPost(long postId, CommunityCreateDTO communityCreateDTO, long userId);
     int deleteCommunityPost(long postId, long userId);
+    List<CommunitySearchDTO> getCommunitySearch(String keyword);
     public int scrapCommunityPost(long reviewId, long userId);
     public int unscrapCommunityPost(long reviewId, long userId);
 }

--- a/src/main/java/com/likelion/boomarble/domain/community/service/CommunityServiceImpl.java
+++ b/src/main/java/com/likelion/boomarble/domain/community/service/CommunityServiceImpl.java
@@ -38,7 +38,6 @@ public class CommunityServiceImpl implements CommunityService {
     private final CommunityTagRepository communityTagRepository;
     private final UniversityInfoRepository universityInfoRepository;
     private final ScrapRepository scrapRepository;
-    private final CommentService commentService;
 
     @Override
     @Transactional
@@ -63,10 +62,9 @@ public class CommunityServiceImpl implements CommunityService {
         if(country != null) { tagList.add(0, country.getName()); }
         if(exType != null) { tagList.add(0, exType.getName()); }
         if(semester != null) { tagList.add(0, semester); }
-
+        community.setCommunityTagList(tagList);
         // 해시태그 추가
         for(String tag : tagList){
-
             Tag checkTag = tagRepository.findByName(tag);
             if (checkTag != null) {
                 checkTag.plusCount();
@@ -97,20 +95,7 @@ public class CommunityServiceImpl implements CommunityService {
     public CommunityDetailDTO getCommunityDetail(long postId) {
         Community community = communityRepository.findById(postId)
                 .orElseThrow(() -> new CommunityNotFoundException("해당 커뮤니티 글이 없습니다."));
-        List<String> tagList = getTagList(postId);
-        return CommunityDetailDTO.from(community, tagList);
-    }
-
-    @Transactional
-    public List<String> getTagList(long postId) {
-        Community community = communityRepository.findById(postId)
-                .orElseThrow(() -> new CommunityNotFoundException("해당 커뮤니티 글이 없습니다."));
-        List<CommunityTagMap> communityTagList = community.getCommunityTagList();
-        List<String> tagList = new ArrayList<>();
-        for(CommunityTagMap tag : communityTagList){
-            tagList.add(tag.getTag().getName().toString());
-        }
-        return tagList;
+        return CommunityDetailDTO.from(community);
     }
 
     @Override

--- a/src/main/java/com/likelion/boomarble/domain/community/service/CommunityServiceImpl.java
+++ b/src/main/java/com/likelion/boomarble/domain/community/service/CommunityServiceImpl.java
@@ -23,10 +23,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -124,6 +121,33 @@ public class CommunityServiceImpl implements CommunityService {
             if (communityRepository.findByIdAndWriter(postId, user).isEmpty()) return 200;
             else return 400;
         } else return 404;
+    }
+
+    @Override
+    @Transactional
+    public List<CommunitySearchDTO> getCommunitySearch(String keyword) {
+        List<Community> posts = communityRepository.findByTitleContaining(keyword);
+        List<Community> tempPosts = communityRepository.findByContentContaining(keyword);
+        tempPosts.addAll(communityRepository.findByCommunityTagListContaining(keyword));
+        for (Community post : tempPosts){
+            if (posts.contains(post)) continue;
+            else posts.add(post);
+        }
+        List<CommunitySearchDTO> searchDTOList = new ArrayList<>();
+        if(posts.isEmpty()) return searchDTOList;
+        for (Community post : posts) {
+            searchDTOList.add(this.convertEntityToDto(post));
+        }
+        return searchDTOList;
+    }
+
+    private CommunitySearchDTO convertEntityToDto(Community post){
+        return CommunitySearchDTO.builder()
+                .writerNickname(post.getWriter().getNickname())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .communityTagList(post.getCommunityTagList())
+                .build();
     }
 
     // Scrap


### PR DESCRIPTION
### 작업한 내용
- tagList 관련 코드를 수정했습니다
> 이전에는 커뮤니티 글 생성 후, 글을 조회할 때 String 리스트로 해시태그들을 가져오도록 구현했습니다. 그러다보니 커뮤니티 글 전체를 조회할 때 태그 목록을 불러올 때 보기 쉬운 형태로 불러오기가 어려웠습니다.(태그 맵 리포지토리에서 해당 포스트에 달린 태그들을 찾아서 하나씩 출력해줬기에 하나의 리스트로 묶기가 어려웠습니다.) 그래서 Community 엔티티에 필드를 추가하여 글 생성 시에 String 리스트로 태그들을 추가하도록 수정했습니다.

- 커뮤니티 글 검색 기능을 추가했습니다.
> 키워드를 입력 받은 후, 해당 키워드를 title, content, communityTagList에서 검색하고, 키워드를 포함하는 글을 리스트로 반환했습니다.

### 논의할 내용
- 커뮤니티 글을 검색할 때 title -> content -> communityTagList 순으로 검색을 진행하는데, 이때 검색된 글들을 인덱스 역순으로 정렬시켜야 하는데 어떻게 하는지 아직 잘 모르겠습니다...ㅠ 좀 더 검색해보겠습니다!

### 추후 작업할 내용
- 소셜 로그인을 구현하겠습니다.
