### PR TITLE
Feat: 마이페이지 목록들 구현

### DIFF
--- a/src/main/java/com/likelion/boomarble/domain/community/dto/CommunityViewDTO.java
+++ b/src/main/java/com/likelion/boomarble/domain/community/dto/CommunityViewDTO.java
@@ -11,11 +11,13 @@ import java.util.List;
 @Getter @Builder
 @AllArgsConstructor @NoArgsConstructor
 public class CommunityViewDTO {
+    private long communityId;
     private String communityTitle;
     private List<String> communityTagList;
 
     public static CommunityViewDTO of (Community community) {
         return CommunityViewDTO.builder()
+                .communityId(community.getId())
                 .communityTitle(community.getTitle())
                 .communityTagList(community.getCommunityTagList()).build();
     }

--- a/src/main/java/com/likelion/boomarble/domain/community/repository/CommunityRepository.java
+++ b/src/main/java/com/likelion/boomarble/domain/community/repository/CommunityRepository.java
@@ -15,4 +15,5 @@ public interface CommunityRepository extends JpaRepository<Community, Long>, Jpa
     List<Community> findByTitleContaining(String keyword);
     List<Community> findByContentContaining(String keyword);
     List<Community> findByCommunityTagListContaining(String keyword);
+    List<Community> findAllByWriter(User user);
 }

--- a/src/main/java/com/likelion/boomarble/domain/model/repository/LikeRepository.java
+++ b/src/main/java/com/likelion/boomarble/domain/model/repository/LikeRepository.java
@@ -4,11 +4,16 @@ import com.likelion.boomarble.domain.model.Like;
 import com.likelion.boomarble.domain.universityInfo.domain.UniversityInfo;
 import com.likelion.boomarble.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface LikeRepository extends JpaRepository<Like, Long> {
     Optional<Like> findByUserAndUniversityInfo(User user, UniversityInfo universityInfo);
+    @Query("SELECT l.universityInfo FROM Like l JOIN l.universityInfo WHERE l.user.id = :userId")
+    List<UniversityInfo> findUniversityInfosByUserId(@Param("userId") long userId);
 }

--- a/src/main/java/com/likelion/boomarble/domain/model/repository/ScrapRepository.java
+++ b/src/main/java/com/likelion/boomarble/domain/model/repository/ScrapRepository.java
@@ -5,10 +5,18 @@ import com.likelion.boomarble.domain.model.Scrap;
 import com.likelion.boomarble.domain.review.domain.Review;
 import com.likelion.boomarble.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ScrapRepository extends JpaRepository<Scrap, Long> {
     Optional<Scrap> findByUserAndReview(User user, Review review);
     Optional<Scrap> findByUserAndCommunity(User user, Community community);
+    @Query("SELECT s.review FROM Scrap s JOIN s.review WHERE s.user.id = :userId AND s.review IS NOT NULL")
+    List<Review> findScrappedReviewsByUserId(@Param("userId") long userId);
+
+    @Query("SELECT s.community FROM Scrap s JOIN s.community WHERE s.user.id = :userId AND s.community IS NOT NULL")
+    List<Community> findScrappedCommunitiesByUserId(@Param("userId") long userId);
 }

--- a/src/main/java/com/likelion/boomarble/domain/prediction/controller/PredictionController.java
+++ b/src/main/java/com/likelion/boomarble/domain/prediction/controller/PredictionController.java
@@ -6,10 +6,7 @@ import com.likelion.boomarble.domain.user.domain.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,29 +18,27 @@ public class PredictionController {
     // 영어권인지 비영어권이지 구별하기 위한 컨트롤러
     @PostMapping("")
     public ResponseEntity determineRegion(Authentication authentication, @RequestBody BasicInformationDTO basicInformationDTO){
-        String region = predictionService.determineRegionByCountry(basicInformationDTO);
-        return ResponseEntity.ok().body(region);
+        return ResponseEntity.ok().body(predictionService.determineRegionByCountry(basicInformationDTO));
     }
 
     @PostMapping("/japanese")
     public ResponseEntity applyJapanesePrediction(Authentication authentication, @RequestBody PredictionJapaneseInfoDTO predictionJapaneseInfoDTO){
-        long userId = getUserPk(authentication);
-        PredictionResultDTO predictionResultDTO = predictionService.applyJapanesePrediction(userId, predictionJapaneseInfoDTO);
-        return ResponseEntity.ok(predictionResultDTO);
+        return ResponseEntity.ok(predictionService.applyJapanesePrediction(getUserPk(authentication), predictionJapaneseInfoDTO));
     }
 
     @PostMapping("/chinese")
     public ResponseEntity applyChinesePrediction(Authentication authentication, @RequestBody PredictionChineseInfoDTO predictionChineseInfoDTO){
-        long userId = getUserPk(authentication);
-        PredictionResultDTO predictionResultDTO = predictionService.applyChinesePrediction(userId, predictionChineseInfoDTO);
-        return ResponseEntity.ok(predictionResultDTO);
+        return ResponseEntity.ok(predictionService.applyChinesePrediction(getUserPk(authentication), predictionChineseInfoDTO));
     }
 
     @PostMapping("/english")
     public ResponseEntity applyEnglishPrediction(Authentication authentication, @RequestBody PredictionEnglishInfoDTO predictionEnglishInfoDTO){
-        long userId = getUserPk(authentication);
-        PredictionResultDTO predictionResultDTO = predictionService.applyEnglishPrediction(userId, predictionEnglishInfoDTO);
-        return ResponseEntity.ok(predictionResultDTO);
+        return ResponseEntity.ok(predictionService.applyEnglishPrediction(getUserPk(authentication), predictionEnglishInfoDTO));
+    }
+
+    @GetMapping("/{predictionId}")
+    public ResponseEntity getPredictionDetail(Authentication authentication, @PathVariable long predictionId){
+        return ResponseEntity.ok(predictionService.getPredictionDetail(getUserPk(authentication), predictionId));
     }
 
     public long getUserPk(Authentication authentication){

--- a/src/main/java/com/likelion/boomarble/domain/prediction/dto/PredictionListDTO.java
+++ b/src/main/java/com/likelion/boomarble/domain/prediction/dto/PredictionListDTO.java
@@ -1,0 +1,28 @@
+package com.likelion.boomarble.domain.prediction.dto;
+
+import com.likelion.boomarble.domain.prediction.domain.Prediction;
+import com.likelion.boomarble.domain.universityInfo.domain.UniversityInfo;
+import com.likelion.boomarble.domain.universityInfo.dto.UniversityInfoListDTO;
+import com.likelion.boomarble.domain.universityInfo.dto.UniversityInfoViewDTO;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PredictionListDTO {
+    private List<PredictionViewDTO> prediction;
+    public static PredictionListDTO from(List<Prediction> predictions) {
+        List<PredictionViewDTO> viewDTOList = predictions.stream()
+                .map(PredictionViewDTO::of)
+                .collect(Collectors.toList());
+
+        return new PredictionListDTO(viewDTOList);
+    }
+}

--- a/src/main/java/com/likelion/boomarble/domain/prediction/dto/PredictionViewDTO.java
+++ b/src/main/java/com/likelion/boomarble/domain/prediction/dto/PredictionViewDTO.java
@@ -1,0 +1,29 @@
+package com.likelion.boomarble.domain.prediction.dto;
+
+import com.likelion.boomarble.domain.prediction.domain.Prediction;
+import com.likelion.boomarble.domain.universityInfo.domain.UniversityInfo;
+import com.likelion.boomarble.domain.universityInfo.dto.UniversityInfoViewDTO;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PredictionViewDTO {
+    private long predictionId;
+    private String predictionUniversityName;
+    private String predictionUniversityCountry;
+    private String predictionUniversityExType;
+    public static PredictionViewDTO of(Prediction prediction){
+        return PredictionViewDTO.builder()
+                .predictionId(prediction.getId())
+                .predictionUniversityName(prediction.getUniversity().getName())
+                .predictionUniversityCountry(prediction.getCountry().getName())
+                .predictionUniversityExType(prediction.getExType().getName()).build();
+    }
+}

--- a/src/main/java/com/likelion/boomarble/domain/prediction/exception/PredictionNotFoundException.java
+++ b/src/main/java/com/likelion/boomarble/domain/prediction/exception/PredictionNotFoundException.java
@@ -1,0 +1,7 @@
+package com.likelion.boomarble.domain.prediction.exception;
+
+public class PredictionNotFoundException extends RuntimeException{
+    public PredictionNotFoundException(String message){
+        super(message);
+    }
+}

--- a/src/main/java/com/likelion/boomarble/domain/prediction/repository/PredictionRepository.java
+++ b/src/main/java/com/likelion/boomarble/domain/prediction/repository/PredictionRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface PredictionRepository extends JpaRepository<Prediction, Long> {
@@ -34,4 +35,6 @@ public interface PredictionRepository extends JpaRepository<Prediction, Long> {
             nativeQuery = true)
     List<Object[]> findEnglishRankingsByUniversityId(@Param("universityId") long universityId, @Param("exType") int exType);
     Prediction findByUserAndExTypeAndUniversity(User user, ExType exType, UniversityInfo universityInfo);
+    List<Prediction> findAllByUser(User user);
+    Optional<Prediction> findByUserAndId(User user, long id);
 }

--- a/src/main/java/com/likelion/boomarble/domain/prediction/service/PredictionService.java
+++ b/src/main/java/com/likelion/boomarble/domain/prediction/service/PredictionService.java
@@ -13,4 +13,6 @@ public interface PredictionService {
     PredictionResultDTO applyChinesePrediction(long userId, PredictionChineseInfoDTO predictionChineseInfoDTO);
 
     PredictionResultDTO applyEnglishPrediction(long userId, PredictionEnglishInfoDTO predictionEnglishInfoDTO);
+
+    PredictionResultDTO getPredictionDetail(long userPk, long predictionId);
 }

--- a/src/main/java/com/likelion/boomarble/domain/review/dto/ReviewListDTO.java
+++ b/src/main/java/com/likelion/boomarble/domain/review/dto/ReviewListDTO.java
@@ -1,0 +1,25 @@
+package com.likelion.boomarble.domain.review.dto;
+
+import com.likelion.boomarble.domain.review.domain.Review;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReviewListDTO {
+    private List<ReviewViewDTO> reviewLists;
+    public static ReviewListDTO from(List<Review> reviews){
+        List<ReviewViewDTO> viewDTOList = reviews.stream()
+                .map(ReviewViewDTO::of)
+                .collect(Collectors.toList());
+
+        return new ReviewListDTO(viewDTOList);
+    }
+}

--- a/src/main/java/com/likelion/boomarble/domain/review/dto/ReviewViewDTO.java
+++ b/src/main/java/com/likelion/boomarble/domain/review/dto/ReviewViewDTO.java
@@ -1,0 +1,33 @@
+package com.likelion.boomarble.domain.review.dto;
+
+import com.likelion.boomarble.domain.review.domain.Review;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReviewViewDTO {
+    private long reviewId;
+    private long userId;
+    private String userNickName;
+    private String universityName;
+    private String universityCountry;
+    private String universityType;
+    private String universitySemester;
+
+    public static ReviewViewDTO of(Review review){
+        return ReviewViewDTO.builder()
+                .reviewId(review.getId())
+                .userId(review.getWriter().getId())
+                .userNickName(review.getWriter().getNickname())
+                .universityName(review.getUniversityInfo().getName())
+                .universityCountry(review.getUniversityInfo().getCountry().getName())
+                .universityType(review.getUniversityInfo().getExType().getName())
+                .universitySemester(review.getSemester())
+                .build();
+    }
+}

--- a/src/main/java/com/likelion/boomarble/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/likelion/boomarble/domain/review/repository/ReviewRepository.java
@@ -2,6 +2,7 @@ package com.likelion.boomarble.domain.review.repository;
 
 import com.likelion.boomarble.domain.model.ExType;
 import com.likelion.boomarble.domain.review.domain.Review;
+import com.likelion.boomarble.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,6 +13,5 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     @Query("SELECT r FROM Review r WHERE r.universityInfo.id = :universityInfoId")
     List<Review> findByUniversityInfo_Id(@Param("universityInfoId") long universityInfoId);
-
-
+    List<Review> findAllByWriter(User user);
 }

--- a/src/main/java/com/likelion/boomarble/domain/universityInfo/dto/UniversityInfoDetailDTO.java
+++ b/src/main/java/com/likelion/boomarble/domain/universityInfo/dto/UniversityInfoDetailDTO.java
@@ -14,6 +14,7 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 public class UniversityInfoDetailDTO {
+    private long universityId;
     private String universityName;
     private String exType; // 교환유형(교환학생, 7+1)
     private String country;
@@ -33,6 +34,7 @@ public class UniversityInfoDetailDTO {
 
     public static UniversityInfoDetailDTO from(UniversityInfo universityInfo) {
         return UniversityInfoDetailDTO.builder()
+                .universityId(universityInfo.getId())
                 .universityName(universityInfo.getName())
                 .exType(universityInfo.getExType().getName())
                 .country(universityInfo.getCountry().getName())
@@ -40,8 +42,8 @@ public class UniversityInfoDetailDTO {
                 .recruitNum(universityInfo.getRecruitNum())
                 .gradeQ(universityInfo.getGradeQ())
                 .ibtQ(universityInfo.getEnglishQ() != null ? universityInfo.getEnglishQ().getIbtQ() : -1)
-                .toeflQ(universityInfo.getEnglishQ().getToefl())
-                .ielts(universityInfo.getEnglishQ().getIeltsQ())
+                .toeflQ(universityInfo.getEnglishQ() != null ? universityInfo.getEnglishQ().getToefl() : -1)
+                .ielts(universityInfo.getEnglishQ() != null ? universityInfo.getEnglishQ().getIeltsQ() : -1)
                 .japaneseQ(universityInfo.getJapaneseQ() != null ? universityInfo.getJapaneseQ().getJapanese() : "")
                 .chineseQ(universityInfo.getChineseQList())
                 .qualificationEtc(universityInfo.getQualificationEtc())

--- a/src/main/java/com/likelion/boomarble/domain/universityInfo/dto/UniversityInfoViewDTO.java
+++ b/src/main/java/com/likelion/boomarble/domain/universityInfo/dto/UniversityInfoViewDTO.java
@@ -11,6 +11,7 @@ import javax.persistence.criteria.CriteriaBuilder;
 @Getter @Builder
 @NoArgsConstructor @AllArgsConstructor
 public class UniversityInfoViewDTO {
+    private long universityId;
     private String universityName;
     private String universityCountry;
     private String universityType;
@@ -18,6 +19,7 @@ public class UniversityInfoViewDTO {
 
     public static UniversityInfoViewDTO of(UniversityInfo universityInfo){
         return UniversityInfoViewDTO.builder()
+                .universityId(universityInfo.getId())
                 .universityName(universityInfo.getName())
                 .universityCountry(universityInfo.getCountry().getName())
                 .universityType(universityInfo.getExType().getName())

--- a/src/main/java/com/likelion/boomarble/domain/user/controller/MyPageController.java
+++ b/src/main/java/com/likelion/boomarble/domain/user/controller/MyPageController.java
@@ -1,0 +1,46 @@
+package com.likelion.boomarble.domain.user.controller;
+
+import com.likelion.boomarble.domain.user.domain.CustomUserDetails;
+import com.likelion.boomarble.domain.user.service.MyPageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/mypage")
+@RestController
+public class MyPageController {
+
+    private final MyPageService myPageService;
+    @GetMapping("/universities")
+    public ResponseEntity getLikeUniversityList(Authentication authentication){
+        return ResponseEntity.ok(myPageService.getLikeUniversityList(getUserPk(authentication)));
+    }
+    @GetMapping("/communities")
+    public ResponseEntity getScrapCommunityList(Authentication authentication){
+        return ResponseEntity.ok(myPageService.getScrapCommunityList(getUserPk(authentication)));
+    }
+    @GetMapping("/reviews")
+    public ResponseEntity getScrapReviewList(Authentication authentication){
+        return ResponseEntity.ok(myPageService.getScrapReviewList(getUserPk(authentication)));
+    }
+    @GetMapping("/applies")
+    public ResponseEntity getApplyList(Authentication authentication){
+        return ResponseEntity.ok(myPageService.getApplyList(getUserPk(authentication)));
+    }
+    @GetMapping("/posts")
+    public ResponseEntity getPostList(Authentication authentication
+            , @RequestParam(value = "type", required = true) String type){
+        if(type.equals("community")){
+            return ResponseEntity.ok(myPageService.getCommunityPostList(getUserPk(authentication)));
+        }else return ResponseEntity.ok(myPageService.getReviewPostList(getUserPk(authentication)));
+    }
+    public long getUserPk(Authentication authentication){
+        CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
+        return customUserDetails.getUserPk();
+    }
+}

--- a/src/main/java/com/likelion/boomarble/domain/user/service/MyPageService.java
+++ b/src/main/java/com/likelion/boomarble/domain/user/service/MyPageService.java
@@ -1,0 +1,15 @@
+package com.likelion.boomarble.domain.user.service;
+
+import com.likelion.boomarble.domain.community.dto.CommunityListDTO;
+import com.likelion.boomarble.domain.prediction.dto.PredictionListDTO;
+import com.likelion.boomarble.domain.review.dto.ReviewListDTO;
+import com.likelion.boomarble.domain.universityInfo.dto.UniversityInfoListDTO;
+
+public interface MyPageService {
+    UniversityInfoListDTO getLikeUniversityList(long userId);
+    CommunityListDTO getScrapCommunityList(long userId);
+    ReviewListDTO getScrapReviewList(long userId);
+    PredictionListDTO getApplyList(long userId);
+    CommunityListDTO getCommunityPostList(long userId);
+    ReviewListDTO getReviewPostList(long userId);
+}

--- a/src/main/java/com/likelion/boomarble/domain/user/service/MyPageServiceImpl.java
+++ b/src/main/java/com/likelion/boomarble/domain/user/service/MyPageServiceImpl.java
@@ -1,0 +1,80 @@
+package com.likelion.boomarble.domain.user.service;
+
+import com.likelion.boomarble.domain.community.domain.Community;
+import com.likelion.boomarble.domain.community.dto.CommunityListDTO;
+import com.likelion.boomarble.domain.community.repository.CommunityRepository;
+import com.likelion.boomarble.domain.model.repository.LikeRepository;
+import com.likelion.boomarble.domain.model.repository.ScrapRepository;
+import com.likelion.boomarble.domain.prediction.domain.Prediction;
+import com.likelion.boomarble.domain.prediction.dto.PredictionListDTO;
+import com.likelion.boomarble.domain.prediction.repository.PredictionRepository;
+import com.likelion.boomarble.domain.review.domain.Review;
+import com.likelion.boomarble.domain.review.dto.ReviewListDTO;
+import com.likelion.boomarble.domain.review.repository.ReviewRepository;
+import com.likelion.boomarble.domain.universityInfo.domain.UniversityInfo;
+import com.likelion.boomarble.domain.universityInfo.dto.UniversityInfoListDTO;
+import com.likelion.boomarble.domain.user.domain.User;
+import com.likelion.boomarble.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MyPageServiceImpl implements MyPageService{
+    private final UserRepository userRepository;
+    private final LikeRepository likeRepository;
+    private final ScrapRepository scrapRepository;
+    private final PredictionRepository predictionRepository;
+    private final CommunityRepository communityRepository;
+    private final ReviewRepository reviewRepository;
+    @Override
+    public UniversityInfoListDTO getLikeUniversityList(long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UsernameNotFoundException("해당 유저가 존재하지 않습니다."));
+        List<UniversityInfo> universityInfoList = likeRepository.findUniversityInfosByUserId(userId);
+        return UniversityInfoListDTO.from(universityInfoList);
+    }
+
+    @Override
+    public CommunityListDTO getScrapCommunityList(long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UsernameNotFoundException("해당 유저가 존재하지 않습니다."));
+        List<Community> communityList = scrapRepository.findScrappedCommunitiesByUserId(userId);
+        return CommunityListDTO.from(communityList);
+    }
+
+    @Override
+    public ReviewListDTO getScrapReviewList(long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UsernameNotFoundException("해당 유저가 존재하지 않습니다."));
+        List<Review> reviewList = scrapRepository.findScrappedReviewsByUserId(userId);
+        return ReviewListDTO.from(reviewList);
+    }
+
+    @Override
+    public PredictionListDTO getApplyList(long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UsernameNotFoundException("해당 유저가 존재하지 않습니다."));
+        List<Prediction> predictionList = predictionRepository.findAllByUser(user);
+        return PredictionListDTO.from(predictionList);
+    }
+
+    @Override
+    public CommunityListDTO getCommunityPostList(long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UsernameNotFoundException("해당 유저가 존재하지 않습니다."));
+        List<Community> communityList = communityRepository.findAllByWriter(user);
+        return CommunityListDTO.from(communityList);
+    }
+
+    @Override
+    public ReviewListDTO getReviewPostList(long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UsernameNotFoundException("해당 유저가 존재하지 않습니다."));
+        List<Review> reviewList = reviewRepository.findAllByWriter(user);
+        return ReviewListDTO.from(reviewList);
+    }
+}


### PR DESCRIPTION
### 작업한 내용
- 마이페이지 구현했습니다.
  - 스크랩 커뮤니티 목록 조회
  - 스크랩 리뷰 목록 조회
  - 내가 쓴 게시물(커뮤니티, 리뷰) 목록 조회
  - 모의지원한 학교 목록 조회
  - 좋아요한 학교 정보 목록 조회
- 상세 조회할 때, 커뮤니티, 리뷰, 대학 정보 모두 클라이언트 측에서 id가 필요하기 때문에 목록 조회때 쓰는 viewDTO에 각각 id를 추가하였습니다.